### PR TITLE
PMM-8151Changes for Remote Instance Helper

### DIFF
--- a/codeceptConfigHelper.js
+++ b/codeceptConfigHelper.js
@@ -34,6 +34,7 @@ module.exports = {
     qanPage: './tests/QAN/pages/qanPage.js',
     qanPagination: './tests/QAN/pages/qanPaginationFragment.js',
     remoteInstancesPage: './tests/pages/remoteInstancesPage.js',
+    remoteInstancesHelper: './tests/remoteInstances/remoteInstancesHelper.js',
     rulesAPI: './tests/ia/pages/api/rulesAPI.js',
     ruleTemplatesPage: './tests/ia/pages/ruleTemplatesPage.js',
     iaCommon: './tests/ia/pages/iaCommonPage.js',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 ---
 version: '3.7'
 
+volumes:
+  pmm-server-data:
+    external: true
+
 services:
   pmm-server:
     image: ${PMM_SERVER_IMAGE:-perconalab/pmm-server:dev-latest}
@@ -16,7 +20,7 @@ services:
       - DISABLE_TELEMETRY=${DISABLE_TELEMETRY:-false}
       - DATA_RETENTION=${DATA_RETENTION:-48h}
     volumes:
-      - ./testdata/checks:/srv/checks
+      - pmm-server-data:/srv
 
   # It is essential to have an extra directory `/slowlogs/` between host and container;
   # Otherwise, MySQL in Docker for Mac completely locks during/after slowlog rotation tests.
@@ -36,7 +40,7 @@ services:
       - MYSQL_PASSWORD=pmm%*&agent-password
       - UMASK=0777  # for slowlog file
     volumes:
-      - /tmp/mysql/log:/tmp/mysql/log
+      - /tmp/mysql/log:/tmp/mysql/log:rw
 
   mysql8:
     image: ${MYSQL_IMAGE:-percona:8.0}
@@ -112,7 +116,7 @@ services:
       - "6033:6033"
       - "6070:6070"
     volumes:
-      - ${PWD}/testdata/proxysql/proxysql.cnf:/etc/proxysql.cnf
+      - ${PWD}/testdata/proxysql/proxysql.cnf:/etc/proxysql.cnf:rw
 
   sysbench:
     image: perconalab/sysbench

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 services:
   pmm-server:
     image: ${PMM_SERVER_IMAGE:-perconalab/pmm-server:dev-latest}
-    container_name: pmm-agent_pmm-server
+    container_name: pmm-server
     ports:
       - "80:80"
       - "443:443"
@@ -16,48 +16,58 @@ services:
     volumes:
       - ./testdata/checks:/srv/checks
 
-  test_db:
-    image: aleksi/test_db:1.1.0
-    container_name: pmm-agent_test_db
-    volumes:
-      - test_db_mysql:/test_db/mysql/world:ro
-      - test_db_postgres:/test_db/postgresql/world:ro
-
   # It is essential to have an extra directory `/slowlogs/` between host and container;
-  # and to not have a trailing slash at `./testdata/mysql`.
   # Otherwise, MySQL in Docker for Mac completely locks during/after slowlog rotation tests.
   mysql:
     image: ${MYSQL_IMAGE:-percona:5.7.30}
-    container_name: pmm-agent_mysql
+    container_name: pmm-agent_mysql_5_7
     command: >
       --sql-mode="ANSI_QUOTES"
-      --performance-schema --innodb_monitor_enable=all
-      --slow_query_log --log_slow_rate_limit=1 --log_slow_admin_statements --log_slow_slave_statements --slow_query_log_file=/mysql/slowlogs/slow.log --long_query_time=0
+      --performance-schema --innodb_monitor_enable=all --userstat
+      --slow_query_log --log_slow_rate_limit=1 --log_slow_admin_statements --log_slow_slave_statements --slow_query_log_file=/tmp/mysql/log/ps5_slow_log.log --long_query_time=0
+      --character-set-server=utf8 --default-authentication-plugin=mysql_native_password --collation-server=utf8_unicode_ci
     ports:
       - "3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=ps
       - MYSQL_USER=pmm-agent
-      - MYSQL_PASSWORD=pmm-agent-password
+      - MYSQL_PASSWORD=pmm%*&agent-password
       - UMASK=0777  # for slowlog file
     volumes:
-      - test_db_mysql:/docker-entrypoint-initdb.d/:ro
-      - ./testdata/mysql:/mysql
+      - /tmp/mysql/log:/tmp/mysql/log
+
+  mysql8:
+    image: ${MYSQL_IMAGE:-percona:8.0}
+    container_name: pmm-agent_mysql_8_0
+    command: >
+      --sql-mode="ANSI_QUOTES"
+      --performance-schema --innodb_monitor_enable=all --userstat
+      --slow_query_log --log_slow_rate_limit=1 --log_slow_admin_statements --log_slow_slave_statements --slow_query_log_file=/tmp/mysql/log/ps8_slow_log.log --long_query_time=0
+      --character-set-server=utf8 --default-authentication-plugin=mysql_native_password --collation-server=utf8_unicode_ci
+    ports:
+      - "3307:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=ps
+      - MYSQL_USER=pmm-agent
+      - MYSQL_PASSWORD=pmm!^%*@agent-password
+      - UMASK=0777  # for slowlog file
+    volumes:
+      - /tmp/mysql/log:/tmp/mysql/log
 
   mongo:
     image: ${MONGO_IMAGE:-percona/percona-server-mongodb:4.2.8}
     container_name: pmm-agent_mongo
     command: --profile 2
     ports:
-      - 127.0.0.1:27017:27017
+      - "27017:27017"
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
-      - MONGO_INITDB_ROOT_PASSWORD=root-password
+      - MONGO_INITDB_ROOT_PASSWORD=root-!@#%^password
 
   mongo_with_ssl:
     image: ${MONGO_IMAGE:-percona/percona-server-mongodb:4.4}
     ports:
-      - 127.0.0.1:27018:27017
+      - "27018:27017"
     command:
       - --profile=2
       - --sslMode=requireSSL
@@ -66,20 +76,20 @@ services:
       - --sslWeakCertificateValidation
       - --bind_ip=0.0.0.0
     volumes:
-      - ${PWD}/utils/tests/testdata/mongodb:/etc/ssl/certificates
+      - ${PWD}/testdata/mongodb:/etc/ssl/certificates
 
   mongonoauth:
     image: ${MONGO_IMAGE:-percona/percona-server-mongodb:4.2.8}
     container_name: pmm-agent_mongonoauth
     command: --profile 2
     ports:
-      - 127.0.0.1:27019:27017
+      - "27019:27017"
 
   postgres:
     image: ${POSTGRES_IMAGE:-perconalab/percona-distribution-postgresql:13.3}
     container_name: pmm-agent_postgres
     command: >
-      -c shared_preload_libraries='${PG_PRELOADED_LIBS:-pg_stat_statements,pg_stat_monitor}'
+      -c shared_preload_libraries=pg_stat_monitor,pg_stat_statements
       -c track_activity_query_size=2048
       -c pg_stat_statements.max=10000
       -c pg_stat_monitor.pgsm_query_max_len=10000
@@ -88,12 +98,19 @@ services:
       -c pg_stat_statements.save=off
       -c track_io_timing=on
     ports:
-      - 127.0.0.1:5432:5432
+      - "5432:5432"
     environment:
-      - POSTGRES_USER=pmm-agent
-      - POSTGRES_PASSWORD=pmm-agent-password
+      - POSTGRES_PASSWORD=pmm-^*&@agent-password
+
+  proxysql:
+    image: ${PROXYSQL_IMAGE:-proxysql/proxysql:2.1.1}
+    container_name: pmm-agent_proxysql
+    ports:
+      - "6032:6032"
+      - "6033:6033"
+      - "6070:6070"
     volumes:
-      - test_db_postgres:/docker-entrypoint-initdb.d/
+      - ${PWD}/testdata/proxysql/proxysql.cnf:/etc/proxysql.cnf
 
   sysbench:
     image: perconalab/sysbench
@@ -141,6 +158,3 @@ services:
               run
       "
 
-volumes:
-  test_db_mysql:
-  test_db_postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - PMM_DEBUG=1
       - PERCONA_TEST_SAAS_HOST=check-dev.percona.com:443
       - PERCONA_TEST_CHECKS_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX
+      - DISABLE_TELEMETRY=${DISABLE_TELEMETRY:-false}
+      - DATA_RETENTION=${DATA_RETENTION:-48h}
     volumes:
       - ./testdata/checks:/srv/checks
 
@@ -157,4 +159,3 @@ services:
               /usr/share/sysbench/tests/include/oltp_legacy/select.lua \
               run
       "
-

--- a/testdata/db_setup.sh
+++ b/testdata/db_setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 
-## Slowlog volume shared with docker container
-chmod 777 -R /tmp/mysql
+## Slowlog file shared with ps docker container, to allow pmm-agent to read
+sudo chmod 777 -R /tmp/mysql/log
 
 ## setup as we do in pmm-framework
 docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "SET GLOBAL slow_query_log='ON';"

--- a/testdata/db_setup.sh
+++ b/testdata/db_setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+
+## Slowlog volume shared with docker container
+chmod 777 -R /tmp/mysql
+
+## setup as we do in pmm-framework
+docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "SET GLOBAL slow_query_log='ON';"
+docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "INSTALL PLUGIN QUERY_RESPONSE_TIME_AUDIT SONAME 'query_response_time.so';"
+docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "INSTALL PLUGIN QUERY_RESPONSE_TIME SONAME 'query_response_time.so';"
+docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "INSTALL PLUGIN QUERY_RESPONSE_TIME_READ SONAME 'query_response_time.so';"
+docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "INSTALL PLUGIN QUERY_RESPONSE_TIME_WRITE SONAME 'query_response_time.so';"
+docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "SET GLOBAL query_response_time_stats=ON;"
+docker exec pmm-agent_mysql_5_7 mysql -h 127.0.0.1 -u root -pps -e "GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO 'pmm-agent'@'%';"
+
+
+## setup as we do in pmm-framework
+docker exec pmm-agent_mysql_8_0 mysql -h 127.0.0.1 -u root -pps -e "SET GLOBAL slow_query_log='ON';"
+docker exec pmm-agent_mysql_8_0 mysql -h 127.0.0.1 -u root -pps -e "GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO 'pmm-agent'@'%';"
+
+## Percona-distribution postgresql
+docker exec pmm-agent_postgres psql -h localhost -U postgres -c 'create extension pg_stat_statements'
+docker exec pmm-agent_postgres psql -h localhost -U postgres -c 'create extension pg_stat_monitor'
+docker exec pmm-agent_postgres psql -h localhost -U postgres -c 'SELECT pg_reload_conf();'

--- a/testdata/mysql/ssl-cert-scripts/gencerts.sh
+++ b/testdata/mysql/ssl-cert-scripts/gencerts.sh
@@ -1,0 +1,12 @@
+
+mkdir -p certs
+
+OPENSSL_SUBJ="/C=US/ST=California/L=Santa Clara"
+OPENSSL_CA="${OPENSSL_SUBJ}/CN=fake-CA"
+OPENSSL_SERVER="${OPENSSL_SUBJ}/CN=fake-server"
+OPENSSL_CLIENT="${OPENSSL_SUBJ}/CN=fake-client"
+
+sh ./genroot.sh "${OPENSSL_CA}"
+sh ./genserver.sh "${OPENSSL_SERVER}"
+sh ./genclient.sh "${OPENSSL_CLIENT}"
+

--- a/testdata/mysql/ssl-cert-scripts/genclient.sh
+++ b/testdata/mysql/ssl-cert-scripts/genclient.sh
@@ -1,0 +1,21 @@
+
+# Create the client-side certificates
+
+OPENSSL_CLIENT=$1
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl req -newkey rsa:2048 -days 3600 -nodes \
+        -subj "${OPENSSL_CLIENT}" \
+        -keyout /certs/client-key.pem -out /certs/client-req.pem
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl rsa -in /certs/client-key.pem -out /certs/client-key.pem
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl x509 -req -in /certs/client-req.pem -days 3600 \
+        -CA /certs/root-ca.pem -CAkey /certs/root-ca-key.pem \
+        -set_serial 01 -out /certs/client-cert.pem
+
+# Verify the certificates are correct
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl verify -CAfile /certs/root-ca.pem /certs/client-cert.pem

--- a/testdata/mysql/ssl-cert-scripts/genroot.sh
+++ b/testdata/mysql/ssl-cert-scripts/genroot.sh
@@ -1,0 +1,12 @@
+
+# Generate new CA certificate root-ca.pem file.
+
+OPENSSL_ROOT_CA=$1
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl genrsa 2048 > certs/root-ca-key.pem
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl req -new -x509 -nodes -days 3600 \
+        -subj "${OPENSSL_ROOT_CA}" \
+        -key /certs/root-ca-key.pem -out /certs/root-ca.pem

--- a/testdata/mysql/ssl-cert-scripts/genserver.sh
+++ b/testdata/mysql/ssl-cert-scripts/genserver.sh
@@ -1,0 +1,22 @@
+
+# Create the server-side certificates
+# This has more interaction that must be automated
+
+OPENSSL_SERVER=$1
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl req -newkey rsa:2048 -days 3600 -nodes \
+        -subj "${OPENSSL_SERVER}" \
+        -keyout /certs/server-key.pem -out /certs/server-req.pem
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl rsa -in /certs/server-key.pem -out /certs/server-key.pem
+
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl x509 -req -in /certs/server-req.pem -days 3600 \
+        -CA /certs/root-ca.pem -CAkey /certs/root-ca-key.pem \
+        -set_serial 01 -out /certs/server-cert.pem
+
+# Verify the certificates are correct
+docker run --rm -v $PWD/certs:/certs -it nginx \
+    openssl verify -CAfile /certs/root-ca.pem /certs/server-cert.pem

--- a/testdata/proxysql/proxysql.cnf
+++ b/testdata/proxysql/proxysql.cnf
@@ -1,0 +1,34 @@
+datadir="/var/lib/proxysql"
+
+admin_variables=
+{
+    admin_credentials="admin:admin;radmin:radmin"
+    mysql_ifaces="0.0.0.0:6032"
+}
+
+mysql_variables=
+{
+    threads=4
+    max_connections=2048
+    default_query_delay=0
+    default_query_timeout=36000000
+    have_compress=true
+    poll_timeout=2000
+    interfaces="0.0.0.0:6033"
+    default_schema="information_schema"
+    stacksize=1048576
+    server_version="5.7.30"
+    connect_timeout_server=3000
+    monitor_username="monitor"
+    monitor_password="monitor"
+    monitor_history=600000
+    monitor_connect_interval=60000
+    monitor_ping_interval=10000
+    monitor_read_only_interval=1500
+    monitor_read_only_timeout=500
+    ping_interval_server_msec=120000
+    ping_timeout_server=500
+    commands_stats=true
+    sessions_sort=true
+    connect_retries_on_failure=10
+}

--- a/tests/pages/api/addInstanceAPI.js
+++ b/tests/pages/api/addInstanceAPI.js
@@ -1,36 +1,23 @@
 const assert = require('assert');
 
+const {
+  remoteInstancesHelper,
+} = inject();
+
 const { I } = inject();
 
 module.exports = {
-  // methods for preparing state of an application before test
-  clusterNames: {
-    mysql: 'mysql_clstr',
-    postgresql: 'pgsql_clstr',
-    proxysql: 'proxy_clstr',
-    mongodb: 'mongo_clstr',
-    rds: 'rdsmsql_clstr',
-  },
-
-  instanceTypes: {
-    mysql: 'MySQL',
-    postgresql: 'PostgreSQL',
-    mongodb: 'MongoDB',
-    proxysql: 'ProxySQL',
-    rds: 'RDS',
-  },
-
   async apiAddInstance(type, serviceName, creds) {
     switch (type) {
-      case this.instanceTypes.mongodb:
+      case remoteInstancesHelper.instanceTypes.mongodb:
         return this.addMongodb(serviceName);
-      case this.instanceTypes.mysql:
+      case remoteInstancesHelper.instanceTypes.mysql:
         return this.addMysql(serviceName, creds);
-      case this.instanceTypes.proxysql:
+      case remoteInstancesHelper.instanceTypes.proxysql:
         return this.addProxysql(serviceName);
-      case this.instanceTypes.postgresql:
+      case remoteInstancesHelper.instanceTypes.postgresql:
         return this.addPostgresql(serviceName);
-      case this.instanceTypes.rds:
+      case remoteInstancesHelper.instanceTypes.rds:
         return this.addRDS(serviceName);
       default:
         throw new Error('Unknown instance type');
@@ -46,13 +33,13 @@ module.exports = {
         node_name: serviceName,
         node_type: 'REMOTE_NODE',
       },
-      port: port || 3307,
+      port: port || remoteInstancesHelper.remote_instance.mysql.ps_5_7.port,
       qan_mysql_perfschema: true,
-      address: host || process.env.REMOTE_MYSQL_HOST,
+      address: host || remoteInstancesHelper.remote_instance.mysql.ps_5_7.host,
       service_name: serviceName,
-      username: username || process.env.REMOTE_MYSQL_USER,
-      password: password || process.env.REMOTE_MYSQL_PASSWORD,
-      cluster: this.clusterNames.mysql,
+      username: username || remoteInstancesHelper.remote_instance.mysql.ps_5_7.username,
+      password: password || remoteInstancesHelper.remote_instance.mysql.ps_5_7.password,
+      cluster: remoteInstancesHelper.remote_instance.mysql.ps_5_7.clusterName,
       engine: 'DISCOVER_RDS_MYSQL',
       pmm_agent_id: 'pmm-server',
     };
@@ -72,15 +59,14 @@ module.exports = {
         node_type: 'REMOTE_NODE',
       },
       port: 5432,
-      address: process.env.REMOTE_POSTGRESQL_HOST,
+      address: remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.host,
       service_name: serviceName,
-      username: process.env.REMOTE_POSTGRESQL_USER,
-      password: process.env.REMOTE_POSTGRESSQL_PASSWORD,
-      cluster: this.clusterNames.postgresql,
+      username: remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.username,
+      password: remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.password,
+      cluster: remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.clusterName,
       pmm_agent_id: 'pmm-server',
       qan_postgresql_pgstatements_agent: true,
       tls_skip_verify: true,
-      tls: true,
     };
     const headers = { Authorization: `Basic ${await I.getAuth()}` };
     const resp = await I.sendPostRequest('v1/management/PostgreSQL/Add', body, headers);
@@ -94,12 +80,12 @@ module.exports = {
         node_name: serviceName,
         node_type: 'REMOTE_NODE',
       },
-      port: 6032,
-      address: process.env.REMOTE_PROXYSQL_HOST,
+      port: remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.port,
+      address: remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.host,
       service_name: serviceName,
-      username: process.env.REMOTE_PROXYSQL_USER,
-      password: process.env.REMOTE_PROXYSQL_PASSWORD,
-      cluster: this.clusterNames.proxysql,
+      username: remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.username,
+      password: remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.password,
+      cluster: remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.clusterName,
       pmm_agent_id: 'pmm-server',
       tls_skip_verify: true,
     };
@@ -116,14 +102,13 @@ module.exports = {
         node_type: 'REMOTE_NODE',
       },
       port: 27017,
-      address: process.env.REMOTE_MONGODB_HOST,
+      address: remoteInstancesHelper.remote_instance.mongodb.psmdb_4_2.host,
       service_name: serviceName,
-      username: process.env.REMOTE_MONGODB_USER,
-      password: process.env.REMOTE_MONGODB_PASSWORD,
-      cluster: this.clusterNames.mongodb,
+      username: remoteInstancesHelper.remote_instance.mongodb.psmdb_4_2.username,
+      password: remoteInstancesHelper.remote_instance.mongodb.psmdb_4_2.password,
+      cluster: remoteInstancesHelper.remote_instance.mongodb.psmdb_4_2.clusterName,
       pmm_agent_id: 'pmm-server',
       qan_mongodb_profiler: true,
-      tls: true,
       tls_skip_verify: true,
     };
     const headers = { Authorization: `Basic ${await I.getAuth()}` };
@@ -138,19 +123,19 @@ module.exports = {
         node_name: serviceName,
         node_type: 'REMOTE_NODE',
       },
-      address: process.env.REMOTE_AWS_MYSQL57_HOST,
-      aws_access_key: process.env.AWS_ACCESS_KEY_ID,
-      aws_secret_key: process.env.AWS_SECRET_ACCESS_KEY,
+      address: remoteInstancesHelper.remote_instance.aws.aws_rds_5_7.address,
+      aws_access_key: remoteInstancesHelper.remote_instance.aws.aws_access_key,
+      aws_secret_key: remoteInstancesHelper.remote_instance.aws.aws_secret_key,
       service_name: serviceName,
-      username: process.env.REMOTE_AWS_MYSQL_USER,
-      password: process.env.REMOTE_AWS_MYSQL_PASSWORD,
+      username: remoteInstancesHelper.remote_instance.aws.aws_rds_5_7.username,
+      password: remoteInstancesHelper.remote_instance.aws.aws_rds_5_7.password,
       az: 'us-east-1c',
-      cluster: this.clusterNames.rds,
+      cluster: remoteInstancesHelper.remote_instance.aws.aws_rds_5_7.clusterName,
       engine: 'DISCOVER_RDS_MYSQL',
       instance_id: 'rds-mysql57',
       isRDS: true,
       pmm_agent_id: 'pmm-server',
-      port: 3306,
+      port: remoteInstancesHelper.remote_instance.aws.aws_rds_5_7.port,
       qan_mysql_perfschema: true,
       rds_exporter: true,
       region: 'us-east-1',
@@ -171,9 +156,9 @@ module.exports = {
     let nodeId;
 
     if (process.env.OVF_TEST === 'yes') {
-      nodeId = (await this.apiAddInstance(this.instanceTypes.rds, 'rds-for-stt-all-checks')).node.node_id;
+      nodeId = (await this.apiAddInstance(remoteInstancesHelper.instanceTypes.rds, 'rds-for-stt-all-checks')).node.node_id;
     } else {
-      nodeId = (await this.apiAddInstance(this.instanceTypes.mysql, 'stt-all-checks-mysql-5.7.30', connection)).service.node_id;
+      nodeId = (await this.apiAddInstance(remoteInstancesHelper.instanceTypes.mysql, 'stt-all-checks-mysql-5.7.30', connection)).service.node_id;
     }
 
     return nodeId;

--- a/tests/pages/api/inventoryAPI.js
+++ b/tests/pages/api/inventoryAPI.js
@@ -3,26 +3,6 @@ const assert = require('assert');
 const { I } = inject();
 
 module.exports = {
-  // methods for preparing state of application before test
-  services: {
-    mysql: {
-      serviceType: 'MYSQL_SERVICE',
-      service: 'mysql',
-    },
-    mongodb: {
-      serviceType: 'MONGODB_SERVICE',
-      service: 'mongodb',
-    },
-    postgresql: {
-      serviceType: 'POSTGRESQL_SERVICE',
-      service: 'postgresql',
-    },
-    proxysql: {
-      serviceType: 'PROXYSQL_SERVICE',
-      service: 'proxysql',
-    },
-  },
-
   async verifyServiceExistsAndHasRunningStatus(service, serviceName) {
     let responseService;
 

--- a/tests/pages/remoteInstancesPage.js
+++ b/tests/pages/remoteInstancesPage.js
@@ -13,7 +13,7 @@ module.exports = {
   // setting locators
   postgresqlAzureInputs: {
     userName: remoteInstancesHelper.remote_instance.azure.azure_postgresql.userName,
-    password: remoteInstancesHelper.remote_instance.azure.azure_postgresql.userName,
+    password: remoteInstancesHelper.remote_instance.azure.azure_postgresql.password,
     environment: 'Azure PostgreSQL environment',
     cluster: 'Azure PostgreSQL cluster',
     replicationSet: 'Azure PostgreSQL replica',

--- a/tests/pages/remoteInstancesPage.js
+++ b/tests/pages/remoteInstancesPage.js
@@ -1,49 +1,43 @@
 const {
-  I, adminPage, pmmInventoryPage, codeceptjsConfig,
+  I, adminPage, pmmInventoryPage, codeceptjsConfig, remoteInstancesHelper,
 } = inject();
 const assert = require('assert');
 
 const url = new URL(codeceptjsConfig.config.helpers.Playwright.url);
 
 module.exports = {
-  accessKey: process.env.AWS_ACCESS_KEY_ID,
-  secretKey: process.env.AWS_SECRET_ACCESS_KEY,
+  accessKey: remoteInstancesHelper.remote_instance.aws.aws_access_key,
+  secretKey: remoteInstancesHelper.remote_instance.aws.aws_secret_key,
 
   // insert your locators and methods here
   // setting locators
   postgresqlAzureInputs: {
-    userName: process.env.AZURE_POSTGRES_USER,
-    password: process.env.AZURE_POSTGRES_PASS,
+    userName: remoteInstancesHelper.remote_instance.azure.azure_postgresql.userName,
+    password: remoteInstancesHelper.remote_instance.azure.azure_postgresql.userName,
     environment: 'Azure PostgreSQL environment',
     cluster: 'Azure PostgreSQL cluster',
     replicationSet: 'Azure PostgreSQL replica',
   },
   mysqlAzureInputs: {
-    userName: process.env.AZURE_MYSQL_USER,
-    password: process.env.AZURE_MYSQL_PASS,
+    userName: remoteInstancesHelper.remote_instance.azure.azure_mysql.userName,
+    password: remoteInstancesHelper.remote_instance.azure.azure_mysql.password,
     environment: 'Azure MySQL environment',
     cluster: 'Azure MySQL cluster',
     replicationSet: 'Azure MySQL replica',
   },
   mysqlInputs: {
-    userName: process.env.REMOTE_AWS_MYSQL_USER,
-    password: process.env.REMOTE_AWS_MYSQL_PASSWORD,
+    userName: remoteInstancesHelper.remote_instance.aws.aws_rds_5_6.username,
+    password: remoteInstancesHelper.remote_instance.aws.aws_rds_5_6.password,
     environment: 'RDS MySQL 5.6',
     cluster: 'rds56-cluster',
     replicationSet: 'rds56-replication',
   },
   postgresqlInputs: {
-    userName: process.env.REMOTE_AWS_POSTGRES12_USER,
-    password: process.env.REMOTE_AWS_POSTGRES12_PASSWORD,
+    userName: remoteInstancesHelper.remote_instance.aws.aws_postgresql_12.userName,
+    password: remoteInstancesHelper.remote_instance.aws.aws_postgresql_12.password,
     environment: 'RDS Postgres',
     cluster: 'rdsPostgres-cluster',
     replicationSet: 'rdsPostgres-replication',
-  },
-  services: {
-    mongodb: 'mongodb_remote_new',
-    mysql: 'mysql_remote_new',
-    postgresql: 'postgresql_remote_new',
-    proxysql: 'proxysql_remote_new',
   },
   url: 'graph/add-instance?orgId=1',
   addMySQLRemoteURL: 'graph/add-instance?instance_type=mysql',
@@ -101,7 +95,7 @@ module.exports = {
     usePerformanceSchema2: '//input[@name="qan_mysql_perfschema"]/following-sibling::span[2]',
     usePgStatMonitor: '//label[text()="PG Stat Monitor"]',
     usePgStatStatements: '//label[text()="PG Stat Statements"]',
-    useQANMongoDBProfiler: '//input[@name="qan_mongodb_profiler"]',
+    useQANMongoDBProfiler: '$qan_mongodb_profiler-field-label',
     useTLS: '$tls-field-label',
     userName: '$username-text-input',
     urlInput: '$url-text-input',
@@ -159,38 +153,53 @@ module.exports = {
   fillRemoteFields(serviceName) {
     // eslint-disable-next-line default-case
     switch (serviceName) {
-      case this.services.mysql:
-        I.fillField(this.fields.hostName, process.env.REMOTE_MYSQL_HOST);
-        I.fillField(this.fields.userName, process.env.REMOTE_MYSQL_USER);
-        I.fillField(this.fields.password, process.env.REMOTE_MYSQL_PASSWORD);
+      case remoteInstancesHelper.services.mysql:
+        I.fillField(this.fields.hostName, remoteInstancesHelper.remote_instance.mysql.ps_5_7.host);
+        I.fillField(this.fields.userName, remoteInstancesHelper.remote_instance.mysql.ps_5_7.username);
+        I.fillField(this.fields.password, remoteInstancesHelper.remote_instance.mysql.ps_5_7.password);
         I.appendField(this.fields.portNumber, '');
         I.pressKey(['Shift', 'Home']);
         I.pressKey('Backspace');
-        I.fillField(this.fields.portNumber, '3307');
+        I.fillField(this.fields.portNumber, remoteInstancesHelper.remote_instance.mysql.ps_5_7.port);
         I.fillField(this.fields.serviceName, serviceName);
         I.fillField(this.fields.environment, 'remote-mysql');
         I.fillField(this.fields.cluster, 'remote-mysql-cluster');
         break;
-      case this.services.mongodb:
-        I.fillField(this.fields.hostName, process.env.REMOTE_MONGODB_HOST);
-        I.fillField(this.fields.userName, process.env.REMOTE_MONGODB_USER);
-        I.fillField(this.fields.password, process.env.REMOTE_MONGODB_PASSWORD);
+      case remoteInstancesHelper.services.mongodb:
+        I.fillField(this.fields.hostName, remoteInstancesHelper.remote_instance.mongodb.psmdb_4_2.host);
+        I.fillField(this.fields.userName, remoteInstancesHelper.remote_instance.mongodb.psmdb_4_2.username);
+        I.fillField(this.fields.password, remoteInstancesHelper.remote_instance.mongodb.psmdb_4_2.password);
         I.fillField(this.fields.serviceName, serviceName);
         I.fillField(this.fields.environment, 'remote-mongodb');
         I.fillField(this.fields.cluster, 'remote-mongodb-cluster');
         break;
-      case this.services.postgresql:
-        I.fillField(this.fields.hostName, process.env.REMOTE_POSTGRESQL_HOST);
-        I.fillField(this.fields.userName, process.env.REMOTE_POSTGRESQL_USER);
-        I.fillField(this.fields.password, process.env.REMOTE_POSTGRESSQL_PASSWORD);
+      case remoteInstancesHelper.services.postgresql:
+        I.fillField(
+          this.fields.hostName,
+          remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.host,
+        );
+        I.fillField(
+          this.fields.userName,
+          remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.username,
+        );
+        I.fillField(
+          this.fields.password,
+          remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.password,
+        );
         I.fillField(this.fields.serviceName, serviceName);
         I.fillField(this.fields.environment, 'remote-postgres');
         I.fillField(this.fields.cluster, 'remote-postgres-cluster');
         break;
-      case this.services.proxysql:
-        I.fillField(this.fields.hostName, process.env.REMOTE_PROXYSQL_HOST);
-        I.fillField(this.fields.userName, process.env.REMOTE_PROXYSQL_USER);
-        I.fillField(this.fields.password, process.env.REMOTE_PROXYSQL_PASSWORD);
+      case remoteInstancesHelper.services.proxysql:
+        I.fillField(this.fields.hostName, remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.host);
+        I.fillField(
+          this.fields.userName,
+          remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.username,
+        );
+        I.fillField(
+          this.fields.password,
+          remoteInstancesHelper.remote_instance.proxysql.proxysql_2_1_1.password
+        );
         I.fillField(this.fields.serviceName, serviceName);
         I.fillField(this.fields.environment, 'remote-proxysql');
         I.fillField(this.fields.cluster, 'remote-proxysql-cluster');
@@ -206,9 +215,18 @@ module.exports = {
       case 'postgreDoNotTrack':
       case 'postgresPGStatStatements':
       case 'postgresPgStatMonitor':
-        I.fillField(this.fields.hostName, process.env.REMOTE_POSTGRESQL_HOST);
-        I.fillField(this.fields.userName, process.env.REMOTE_POSTGRESQL_USER);
-        I.fillField(this.fields.password, process.env.REMOTE_POSTGRESSQL_PASSWORD);
+        I.fillField(
+          this.fields.hostName,
+          remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.host,
+        );
+        I.fillField(
+          this.fields.userName,
+          remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.username,
+        );
+        I.fillField(
+          this.fields.password,
+          remoteInstancesHelper.remote_instance.postgresql.pdpgsql_13_3.password,
+        );
         I.fillField(this.fields.serviceName, serviceName);
         break;
     }
@@ -221,12 +239,10 @@ module.exports = {
     I.click(this.fields.skipTLSL);
     // eslint-disable-next-line default-case
     switch (serviceName) {
-      case this.services.mongodb:
-        I.click(this.fields.useTLS);
+      case remoteInstancesHelper.services.mongodb:
         I.click(this.fields.useQANMongoDBProfiler);
         break;
-      case this.services.postgresql:
-        I.click(this.fields.useTLS);
+      case remoteInstancesHelper.services.postgresql:
         I.click(this.fields.usePgStatStatements);
         break;
       case 'rds-mysql56':
@@ -248,10 +264,11 @@ module.exports = {
   },
 
   discoverAzure() {
-    I.fillField(this.fields.clientID, process.env.AZURE_CLIENT_ID);
-    I.fillField(this.fields.clientSecret, process.env.AZURE_CLIENT_SECRET);
-    I.fillField(this.fields.tenantID, process.env.AZURE_TENNANT_ID);
-    I.fillField(this.fields.subscriptionID, process.env.AZURE_SUBSCRIPTION_ID);
+    I.fillField(this.fields.clientID, remoteInstancesHelper.remote_instance.azure.azure_client_id);
+    I.fillField(this.fields.clientSecret, remoteInstancesHelper.remote_instance.azure.azure_client_secret);
+    I.fillField(this.fields.tenantID, remoteInstancesHelper.remote_instance.azure.azure_tenant_id);
+    I.fillField(this.fields.subscriptionID,
+      remoteInstancesHelper.remote_instance.azure.azure_subscription_id);
     I.click(this.fields.discoverBtn);
     this.waitForDiscovery();
   },

--- a/tests/remoteInstances/remoteInstancesHelper.js
+++ b/tests/remoteInstances/remoteInstancesHelper.js
@@ -49,14 +49,14 @@ module.exports = {
   remote_instance: {
     mysql: {
       ps_5_7: {
-        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'mysql',
+        host: 'mysql',
         port: '3306',
         username: 'pmm-agent',
         password: 'pmm%*&agent-password',
         clusterName: 'mysql_clstr',
       },
       ps_8_0: {
-        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'mysql8',
+        host: 'mysql8',
         port: '3307',
         username: 'pmm-agent',
         password: 'pmm!^%*@agent-password',
@@ -65,7 +65,7 @@ module.exports = {
     },
     mongodb: {
       psmdb_4_2: {
-        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'mongo',
+        host: 'mongo',
         port: '27017',
         username: 'root',
         password: 'root-!@#%^password',
@@ -74,7 +74,7 @@ module.exports = {
     },
     postgresql: {
       pdpgsql_13_3: {
-        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'postgres',
+        host: 'postgres',
         port: '5432',
         username: 'postgres',
         password: 'pmm-^*&@agent-password',
@@ -83,7 +83,7 @@ module.exports = {
     },
     proxysql: {
       proxysql_2_1_1: {
-        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'proxysql',
+        host: 'proxysql',
         port: '6032',
         username: 'radmin',
         password: 'radmin',

--- a/tests/remoteInstances/remoteInstancesHelper.js
+++ b/tests/remoteInstances/remoteInstancesHelper.js
@@ -183,6 +183,6 @@ module.exports = {
   qanFilters: ['mysql', 'mongodb', 'postgresql', 'rds'],
 
   getInstanceStatus(instance) {
-    return Object.keys(remoteInstanceStatus).filter(instance);
+    return remoteInstanceStatus[Object.keys(remoteInstanceStatus).filter((dbtype) => dbtype === instance)];
   },
 };

--- a/tests/remoteInstances/remoteInstancesHelper.js
+++ b/tests/remoteInstances/remoteInstancesHelper.js
@@ -1,0 +1,188 @@
+const { I } = inject();
+
+const remoteInstanceStatus = {
+  mysql: {
+    ps_5_7: {
+      enabled: true,
+    },
+    ps_8_0: {
+      enabled: true,
+    },
+  },
+  mongodb: {
+    psmdb_4_2: {
+      enabled: true,
+    },
+  },
+  postgresql: {
+    pdpgsql_13_3: {
+      enabled: true,
+    },
+  },
+  proxysql: {
+    proxysql_2_1_1: {
+      enabled: true,
+    },
+  },
+  aws: {
+    aws_rds_5_7: {
+      enabled: true,
+    },
+    aws_rds_5_6: {
+      enabled: true,
+    },
+    aws_postgresql_12: {
+      enabled: true,
+    },
+  },
+  azure: {
+    azure_mysql: {
+      enabled: true,
+    },
+    azure_postgresql: {
+      enabled: true,
+    },
+  },
+};
+
+module.exports = {
+  remote_instance: {
+    mysql: {
+      ps_5_7: {
+        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'mysql',
+        port: '3306',
+        username: 'pmm-agent',
+        password: 'pmm%*&agent-password',
+        clusterName: 'mysql_clstr',
+      },
+      ps_8_0: {
+        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'mysql8',
+        port: '3307',
+        username: 'pmm-agent',
+        password: 'pmm!^%*@agent-password',
+        clusterName: 'mysql_clstr',
+      },
+    },
+    mongodb: {
+      psmdb_4_2: {
+        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'mongo',
+        port: '27017',
+        username: 'root',
+        password: 'root-!@#%^password',
+        clusterName: 'mongo_clstr',
+      },
+    },
+    postgresql: {
+      pdpgsql_13_3: {
+        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'postgres',
+        port: '5432',
+        username: 'postgres',
+        password: 'pmm-^*&@agent-password',
+        clusterName: 'pgsql_clstr',
+      },
+    },
+    proxysql: {
+      proxysql_2_1_1: {
+        host: process.env.PMM_SERVER_LATEST ? '127.0.0.1' : 'proxysql',
+        port: '6032',
+        username: 'radmin',
+        password: 'radmin',
+        clusterName: 'proxy_clstr',
+      },
+    },
+    aws: {
+      aws_access_key: process.env.AWS_ACCESS_KEY_ID,
+      aws_secret_key: process.env.AWS_SECRET_ACCESS_KEY,
+      aws_rds_5_7: {
+        address: process.env.REMOTE_AWS_MYSQL57_HOST,
+        username: process.env.REMOTE_AWS_MYSQL_USER,
+        password: process.env.REMOTE_AWS_MYSQL_PASSWORD,
+        clusterName: 'aws_rds_mysql_5_7',
+        port: 3306,
+      },
+      aws_rds_5_6: {
+        address: process.env.REMOTE_AWS_MYSQL57_HOST,
+        username: process.env.REMOTE_AWS_MYSQL_USER,
+        password: process.env.REMOTE_AWS_MYSQL_PASSWORD,
+        clusterName: 'aws_rds_mysql_5_6',
+        port: 3306,
+      },
+      aws_postgresql_12: {
+        userName: process.env.REMOTE_AWS_POSTGRES12_USER,
+        password: process.env.REMOTE_AWS_POSTGRES12_PASSWORD,
+        clusterName: 'aws_postgresql_12',
+        port: 5432,
+      },
+    },
+    azure: {
+      azure_client_id: process.env.AZURE_CLIENT_ID,
+      azure_client_secret: process.env.AZURE_CLIENT_SECRET,
+      azure_tenant_id: process.env.AZURE_TENNANT_ID,
+      azure_subscription_id: process.env.AZURE_SUBSCRIPTION_ID,
+      azure_mysql: {
+        userName: process.env.AZURE_MYSQL_USER,
+        password: process.env.AZURE_MYSQL_PASS,
+      },
+      azure_postgresql: {
+        userName: process.env.AZURE_POSTGRES_USER,
+        password: process.env.AZURE_POSTGRES_PASS,
+      },
+    },
+  },
+
+  instanceTypes: {
+    mysql: (remoteInstanceStatus.mysql.ps_5_7.enabled ? 'MySQL' : undefined),
+    postgresql: (remoteInstanceStatus.postgresql.pdpgsql_13_3.enabled ? 'PostgreSQL' : undefined),
+    mongodb: (remoteInstanceStatus.mongodb.psmdb_4_2.enabled ? 'MongoDB' : undefined),
+    proxysql: (remoteInstanceStatus.proxysql.proxysql_2_1_1.enabled ? 'ProxySQL' : undefined),
+    rds: 'RDS',
+  },
+
+  serviceTypes: {
+    mysql: (
+      remoteInstanceStatus.mysql.ps_5_7.enabled ? {
+        serviceType: 'MYSQL_SERVICE',
+        service: 'mysql',
+      } : undefined
+    ),
+    mongodb: (
+      remoteInstanceStatus.mongodb.psmdb_4_2.enabled ? {
+        serviceType: 'MONGODB_SERVICE',
+        service: 'mongodb',
+      } : undefined
+    ),
+    postgresql: (
+      remoteInstanceStatus.postgresql.pdpgsql_13_3.enabled ? {
+        serviceType: 'POSTGRESQL_SERVICE',
+        service: 'postgresql',
+      } : undefined
+    ),
+    proxysql: (
+      remoteInstanceStatus.proxysql.proxysql_2_1_1.enabled ? {
+        serviceType: 'PROXYSQL_SERVICE',
+        service: 'proxysql',
+      } : undefined
+    ),
+  },
+
+  services: {
+    mysql: (remoteInstanceStatus.mysql.ps_5_7.enabled ? 'mysql_remote_new' : undefined),
+    mongodb: (remoteInstanceStatus.mongodb.psmdb_4_2.enabled ? 'mongodb_remote_new' : undefined),
+    postgresql: (remoteInstanceStatus.postgresql.pdpgsql_13_3.enabled ? 'postgresql_remote_new' : undefined),
+    proxysql: (remoteInstanceStatus.proxysql.proxysql_2_1_1.enabled ? 'proxysql_remote_new' : undefined),
+  },
+
+  upgradeServiceNames: {
+    mysql: (remoteInstanceStatus.mysql.ps_5_7.enabled ? 'mysql_upgrade_service' : undefined),
+    mongodb: (remoteInstanceStatus.mongodb.psmdb_4_2.enabled ? 'mongodb_upgrade_scervice' : undefined),
+    postgresql: (remoteInstanceStatus.postgresql.pdpgsql_13_3.enabled ? 'postgres_upgrade_service' : undefined),
+    proxysql: (remoteInstanceStatus.proxysql.proxysql_2_1_1.enabled ? 'proxysql_upgrade_service' : undefined),
+    rds: 'mysql_rds_uprgade_service',
+  },
+
+  qanFilters: ['mysql', 'mongodb', 'postgresql', 'rds'],
+
+  getInstanceStatus(instance) {
+    return Object.keys(remoteInstanceStatus).filter(instance);
+  },
+};

--- a/tests/upgradePMM_test.js
+++ b/tests/upgradePMM_test.js
@@ -176,6 +176,7 @@ Scenario(
   },
 );
 
+// https://jira.percona.com/browse/PMM-8213 logged to track the defect
 xScenario(
   'Verify user can see News Panel @post-upgrade @ami-upgrade @pmm-upgrade  ',
   async ({ I, homePage }) => {
@@ -239,6 +240,7 @@ Scenario(
   },
 );
 
+// PMM-8123 yet to be merged to master hence skipping, was already fixed in RC 2.18.0
 xScenario(
   'Verify Metrics from custom queries for mysqld_exporter after upgrade (UI) @post-upgrade @ami-upgrade @pmm-upgrade',
   async ({ dashboardPage }) => {

--- a/tests/upgradePMM_test.js
+++ b/tests/upgradePMM_test.js
@@ -176,7 +176,7 @@ Scenario(
   },
 );
 
-Scenario(
+xScenario(
   'Verify user can see News Panel @post-upgrade @ami-upgrade @pmm-upgrade  ',
   async ({ I, homePage }) => {
     I.amOnPage(homePage.url);
@@ -236,7 +236,7 @@ Scenario(
   },
 );
 
-Scenario(
+xScenario(
   'Verify Metrics from custom queries for mysqld_exporter after upgrade (UI) @post-upgrade @ami-upgrade @pmm-upgrade',
   async ({ dashboardPage }) => {
     const metricName = 'mysql_performance_schema_memory_summary_current_bytes';

--- a/tests/upgradePMM_test.js
+++ b/tests/upgradePMM_test.js
@@ -218,7 +218,7 @@ Scenario(
 Scenario(
   'Verify QAN has specific filters for Remote Instances after Upgrade (UI) @ami-upgrade @post-upgrade @pmm-upgrade',
   async ({
-    I, qanPage, qanFilters, addInstanceAPI,
+    I, qanPage, qanFilters, qanOverview,
   }) => {
     I.amOnPage(qanPage.url);
     qanFilters.waitForFiltersToLoad();
@@ -228,6 +228,9 @@ Scenario(
     for (const name of Object.keys(remoteInstancesHelper.upgradeServiceNames)) {
       if (remoteInstancesHelper.qanFilters.includes(name)) {
         const filter = qanFilters.getFilterLocator(name);
+
+        qanFilters.waitForFiltersToLoad();
+        qanOverview.waitForOverviewLoaded();
 
         I.waitForVisible(filter, 30);
         I.seeElement(filter);

--- a/tests/verifyAzureMySQLPostgreSQLRemoteInstance_test.js
+++ b/tests/verifyAzureMySQLPostgreSQLRemoteInstance_test.js
@@ -1,14 +1,19 @@
 const assert = require('assert');
 
-const { remoteInstancesPage } = inject();
+const { remoteInstancesPage, remoteInstancesHelper } = inject();
 
 const filters = new DataTable(['filter']);
 const azureServices = new DataTable(['name', 'instanceToMonitor']);
 
-filters.add([remoteInstancesPage.mysqlAzureInputs.environment]);
-filters.add([remoteInstancesPage.postgresqlAzureInputs.environment]);
-azureServices.add(['azure-MySQL', 'pmm2-qa-mysql']);
-azureServices.add(['azure-PostgreSQL', 'pmm2-qa-postgresql']);
+if (remoteInstancesHelper.getInstanceStatus('azure').azure_mysql.enabled) {
+  azureServices.add(['azure-MySQL', 'pmm2-qa-mysql']);
+  filters.add([remoteInstancesPage.mysqlAzureInputs.environment]);
+}
+
+if (remoteInstancesHelper.getInstanceStatus('azure').azure_postgresql.enabled) {
+  azureServices.add(['azure-PostgreSQL', 'pmm2-qa-postgresql']);
+  filters.add([remoteInstancesPage.postgresqlAzureInputs.environment]);
+}
 
 Feature('Monitoring Azure MySQL and PostgreSQL DB');
 


### PR DESCRIPTION
Now the UI/Upgrade tests use docker-compose-based test execution, we no longer need the remote instances. 

1) Upgrade tests modified and all unskipped remote instance tests have been removed. 
2) All the data tables are prepared based on the enable flag in the remote-instance helper, in the future if a setup doesn't work, all we need to do is set the flag to false. 
3) Mysql, MongoDB, PostgreSQL, and proxysql all 4 instances are set up via docker-compose. 
4) Preparing for SSL-based MySQL setup, so adding scripts that would allow us to set up remote MySQL SSL-based setup too. 

The changes for the jobs have been sent to Jenkins pipeline here: https://github.com/Percona-Lab/jenkins-pipelines/pull/1029 
