### PR TITLE
PMM-7690 Discovery based on IAM roles

### DIFF
--- a/tests/pages/remoteInstancesPage.js
+++ b/tests/pages/remoteInstancesPage.js
@@ -86,6 +86,7 @@ module.exports = {
     hostName: '$address-text-input',
     iframe: '//div[@class="panel-content"]//iframe',
     metricsPath: '$metrics_path-text-input',
+    noCredentialsError: '//div[text()="No credentials provided and IAM role is not defined"]',
     pageHeaderText: 'PMM Add Instance',
     parseFromURLRadioButton: locate('label').withText('Parse from URL string'),
     password: '$password-password-input',
@@ -313,6 +314,11 @@ module.exports = {
     I.fillField(this.fields.secretKeyInput, this.secretKey);
     I.click(this.fields.discoverBtn);
     this.waitForDiscovery();
+  },
+
+  discoverRDSWithoutCredentials() {
+    I.click(this.fields.discoverBtn);
+    I.waitForVisible(this.fields.noCredentialsError, 30);
   },
 
   waitForDiscovery() {

--- a/tests/verifyAWSRDSMySQLInstance_test.js
+++ b/tests/verifyAWSRDSMySQLInstance_test.js
@@ -24,6 +24,15 @@ Scenario(
 );
 
 Scenario(
+  'Verify RDS allows discovery without credentials @instances',
+  async ({ I, remoteInstancesPage }) => {
+    I.amOnPage(remoteInstancesPage.url);
+    remoteInstancesPage.waitUntilRemoteInstancesPageLoaded().openAddAWSRDSMySQLPage();
+    remoteInstancesPage.discoverRDSWithoutCredentials();
+  },
+);
+
+Scenario(
   'Verify AWS RDS MySQL 5.6 instance has status running [critical] @instances',
   async ({ I, remoteInstancesPage, pmmInventoryPage }) => {
     const serviceName = remoteInstancesPage.rds['Service Name'];


### PR DESCRIPTION
Adds test to check that is possible to discover RDS instances without credentials. It returns an error since IAM roles are not defined but it proves that discovery is possible.

https://github.com/percona/pmm-doc/pull/579
https://github.com/percona-platform/grafana/pull/221
https://github.com/Percona-Lab/pmm-submodules/pull/1969