### PR TITLE
PMM-8167 Update DB Cluster version

### DIFF
--- a/tests/DbaaS/pages/dbaasActionsPage.js
+++ b/tests/DbaaS/pages/dbaasActionsPage.js
@@ -23,7 +23,7 @@ module.exports = {
     }
   },
 
-  async createClusterBasicOptions(k8sClusterName, dbClusterName, dbType) {
+  async createClusterBasicOptions(k8sClusterName, dbClusterName, dbType, dbVersion) {
     I.waitForElement(dbaasPage.tabs.dbClusterTab.dbClusterAddButtonTop, 30);
     I.waitForInvisible(dbaasPage.tabs.kubernetesClusterTab.disabledAddButton, 30);
     I.click(dbaasPage.tabs.dbClusterTab.dbClusterAddButtonTop);
@@ -41,10 +41,18 @@ module.exports = {
       dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseTypeFieldSelect(dbType),
     );
     I.click(dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseTypeFieldSelect(dbType));
+    
+    if (dbVersion) {
+      I.click(dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseVersionField);
+      I.waitForElement(
+        dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseVersionSelect(dbVersion),
+      );
+      I.click(dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseVersionSelect(dbVersion));
+    }
   },
 
-  async createClusterAdvancedOption(k8sClusterName, dbClusterName, dbType, configuration) {
-    this.createClusterBasicOptions(k8sClusterName, dbClusterName, dbType);
+  async createClusterAdvancedOption(k8sClusterName, dbClusterName, dbType, configuration, dbVersion) {
+    this.createClusterBasicOptions(k8sClusterName, dbClusterName, dbType, dbVersion);
     I.click(dbaasPage.tabs.dbClusterTab.optionsCountLocator(2));
     I.waitForElement(
       dbaasPage.tabs.dbClusterTab.advancedOptions.fields.clusterTopology(configuration.topology), 30,
@@ -188,5 +196,15 @@ module.exports = {
         resourceType,
       ), 'rgb(224, 47, 68)',
     );
+  },
+
+  async updateCluster() {
+    I.waitForElement(dbaasPage.tabs.dbClusterTab.fields.clusterTableHeader, 30);
+    I.click(dbaasPage.tabs.dbClusterTab.fields.clusterActionsMenu);
+    await this.checkActionPossible('Update', true);
+    I.waitForElement(dbaasPage.tabs.dbClusterTab.fields.clusterAction('Update'), 30);
+    I.click(dbaasPage.tabs.dbClusterTab.fields.clusterAction('Update'));
+    I.waitForElement(dbaasPage.tabs.dbClusterTab.fields.updateClusterButton, 30);
+    I.click(dbaasPage.tabs.dbClusterTab.fields.updateClusterButton);
   },
 };

--- a/tests/DbaaS/pages/dbaasPage.js
+++ b/tests/DbaaS/pages/dbaasPage.js
@@ -62,6 +62,7 @@ module.exports = {
           )
             .find('span')
             .withText(version),
+          dbClusterDatabaseVersionSelect: (version) => `//div[@data-qa='dbcluster-database-version-field']//div[contains(@class, 'grafana-select-menu')]//span[contains(., '${version}')]`,
           defaultDbVersionValue: (version) => locate(
             '$dbcluster-database-version-field',
           )
@@ -100,7 +101,7 @@ module.exports = {
         },
       },
       fields: {
-        clusterDetailHeaders: ['Name', 'Database Type', 'Connection', 'DB Cluster Parameters', 'Cluster Status', 'Actions'],
+        clusterDetailHeaders: ['Name', 'Database', 'Connection', 'DB Cluster Parameters', 'Cluster Status', 'Actions'],
         clusterAction: (action) => `//div[@data-qa='dropdown-menu-menu']//span[contains(text(), '${action}')]`,
         clusterConnection: {
           dbHost: '$cluster-connection-host',
@@ -127,6 +128,7 @@ module.exports = {
         clusterStatusPending: '$cluster-status-pending',
         clusterStatusPaused: '$cluster-status-suspended',
         clusterStatusDeleting: '$cluster-status-deleting',
+        clusterStatusUpdating: '$cluster-status-updating',
         clusterTableHeader: locate('$table-header').find('th'),
         clusterTableRow: '$table-row',
         clusterActionsMenu: '$dropdown-menu-toggle',
@@ -139,6 +141,7 @@ module.exports = {
         cancelDeleteDBCluster: '$cancel-delete-dbcluster-button',
         progressBarSteps: '$progress-bar-steps',
         progressBarContent: '$progress-bar-message',
+        updateClusterButton: '$confirm-update-dbcluster-button',
       },
     },
   },

--- a/tests/DbaaS/verifyDBaaSPXCCluster_test.js
+++ b/tests/DbaaS/verifyDBaaSPXCCluster_test.js
@@ -15,7 +15,7 @@ const singleNodeConfiguration = {
   memory: '1.2 GB',
   cpu: '0.2',
   disk: '25 GB',
-  dbType: 'MySQL',
+  dbType: 'MySQL 8.0.22',
   clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.pxcDashboard(pxc_cluster_name_single),
 };
 
@@ -54,7 +54,7 @@ Scenario('PMM-T459, PMM-T473, PMM-T478, PMM-T524 Verify DB Cluster Details are l
   async ({ I, dbaasPage, dbaasActionsPage }) => {
     const clusterDetails = {
       clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.pxcDashboard(pxc_cluster_name),
-      dbType: 'MySQL',
+      dbType: 'MySQL 8.0.22',
       memory: '2 GB',
       cpu: '1',
       disk: '25 GB',
@@ -155,7 +155,7 @@ Scenario('PMM-T488, PMM-T489 Verify editing PXC cluster changing single node to 
       memory: '1 GB',
       cpu: '0.5',
       disk: '25 GB',
-      dbType: 'MySQL',
+      dbType: 'MySQL 8.0.22',
       clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.pxcDashboard(pxc_cluster_name_single),
     };
 
@@ -182,7 +182,7 @@ Scenario('PMM-T525 PMM-T528 Verify Suspend & Resume for DB Cluster Works as expe
       clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.pxcDashboard(
         pxc_cluster_suspend_resume,
       ),
-      dbType: 'MySQL',
+      dbType: 'MySQL 8.0.22',
       memory: '2 GB',
       cpu: '1',
       disk: '25 GB',
@@ -359,4 +359,18 @@ Scenario('PMM-T704 PMM-T772 PMM-T849 PMM-T850 Resources, PV, Secrets verificatio
       '',
       'fail',
     );
+  });
+
+  Scenario('Verify update PXC DB Cluster version @dbaas', async ({ I, dbaasPage, dbaasActionsPage }) => {
+    await dbaasAPI.deleteAllDBCluster(clusterName);
+    await dbaasPage.waitForDbClusterTab(clusterName);
+    I.waitForInvisible(dbaasPage.tabs.kubernetesClusterTab.disabledAddButton, 30);
+    await dbaasActionsPage.createClusterAdvancedOption(clusterName, pxc_cluster_name_single, 'MySQL', singleNodeConfiguration, '8.0.19-10.1');
+    I.click(dbaasPage.tabs.dbClusterTab.createClusterButton);
+    I.waitForText('Processing', 30, dbaasPage.tabs.dbClusterTab.fields.progressBarContent);
+    await dbaasPage.postClusterCreationValidation(pxc_cluster_name_single, clusterName);
+    await dbaasActionsPage.updateCluster();
+    I.waitForVisible(dbaasPage.tabs.dbClusterTab.fields.clusterStatusUpdating, 60);
+    I.seeElement(dbaasPage.tabs.dbClusterTab.fields.clusterStatusUpdating);
+    await dbaasActionsPage.deleteXtraDBCluster(pxc_cluster_name_single, clusterName);
   });

--- a/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
+++ b/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
@@ -10,7 +10,7 @@ const psmdb_configuration = {
   memory: '2 GB',
   cpu: '1',
   disk: '5 GB',
-  dbType: 'MongoDB',
+  dbType: 'MongoDB 4.4.6',
   clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.psmdbDashboard(psmdb_cluster),
 };
 
@@ -107,7 +107,7 @@ Scenario('PMM-787 Verify Editing MonogDB Cluster is possible. @dbaas',
       memory: '1 GB',
       cpu: '0.5',
       disk: '5 GB',
-      dbType: 'MongoDB',
+      dbType: 'MongoDB 4.4.6',
       clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.psmdbDashboard(psmdb_cluster),
     };
 
@@ -130,7 +130,7 @@ xScenario('PMM-T525 PMM-T528 Verify Suspend & Resume for Mongo DB Cluster Works 
       memory: '2 GB',
       cpu: '1',
       disk: '2 GB',
-      dbType: 'MongoDB',
+      dbType: 'MongoDB 4.4.6',
       clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.psmdbDashboard(
         psmdb_cluster_suspend_resume,
       ),
@@ -187,7 +187,7 @@ Scenario('PMM-T704 PMM-T772 PMM-T849 PMM-T850 Resources, PV, Secrets verificatio
       memory: '1 GB',
       cpu: '1',
       disk: '2 GB',
-      dbType: 'MongoDB',
+      dbType: 'MongoDB 4.4.6',
       clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.psmdbDashboard(
         psmdb_cluster_resource_check,
       ),
@@ -240,4 +240,32 @@ Scenario('PMM-T704 PMM-T772 PMM-T849 PMM-T850 Resources, PV, Secrets verificatio
       '',
       'fail',
     );
+  });
+
+  Scenario('Verify update PSMDB Cluster version @dbaas', async ({ I, dbaasPage, dbaasActionsPage }) => {
+    const psmdb_cluster_update = 'psmdb-update';
+    const clusterDetails = {
+      topology: 'Cluster',
+      numberOfNodes: '1',
+      resourcePerNode: 'Custom',
+      memory: '2 GB',
+      cpu: '1',
+      disk: '2 GB',
+      dbType: 'MongoDB 4.4.6',
+      clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.psmdbDashboard(
+        psmdb_cluster_update,
+      ),
+    };
+
+    await dbaasAPI.deleteAllDBCluster(clusterName);
+    await dbaasPage.waitForDbClusterTab(clusterName);
+    I.waitForInvisible(dbaasPage.tabs.kubernetesClusterTab.disabledAddButton, 30);
+    await dbaasActionsPage.createClusterAdvancedOption(clusterName, psmdb_cluster_update, 'MongoDB', clusterDetails, '4.2.8-8');
+    I.click(dbaasPage.tabs.dbClusterTab.createClusterButton);
+    I.waitForText('Processing', 30, dbaasPage.tabs.dbClusterTab.fields.progressBarContent);
+    await dbaasPage.postClusterCreationValidation(psmdb_cluster_update, clusterName);
+    await dbaasActionsPage.updateCluster();
+    I.waitForVisible(dbaasPage.tabs.dbClusterTab.fields.clusterStatusUpdating, 60);
+    I.seeElement(dbaasPage.tabs.dbClusterTab.fields.clusterStatusUpdating);
+    await dbaasActionsPage.deletePSMDBCluster(psmdb_cluster_suspend_resume, clusterName);
   });

--- a/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
+++ b/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
@@ -272,5 +272,5 @@ Scenario('PMM-T704 PMM-T772 PMM-T849 PMM-T850 Resources, PV, Secrets verificatio
     await dbaasActionsPage.updateCluster();
     I.waitForVisible(dbaasPage.tabs.dbClusterTab.fields.clusterStatusUpdating, 60);
     I.seeElement(dbaasPage.tabs.dbClusterTab.fields.clusterStatusUpdating);
-    await dbaasActionsPage.deletePSMDBCluster(psmdb_cluster_suspend_resume, clusterName);
+    await dbaasActionsPage.deletePSMDBCluster(psmdb_cluster_update, clusterName);
   });


### PR DESCRIPTION
- Adds e2e tests for update DB cluster
- Changes column _Database Type_ to _Database_ in DB clusters table
- Adds version to _Database_ column


If we end up having problems because we are using the recommended database version to create the cluster and checking for a hardcoded version we will have to force the creation of cluster to a specific version. It is already allowed by `createClusterBasicOptions` and `createClusterAdvancedOption`.

https://github.com/percona-platform/grafana/pull/228
https://jira.percona.com/browse/PMM-8167