### PR TITLE
PMM-8461-fix-failed-ui-test

### DIFF
--- a/tests/DbaaS/pages/dbaasPage.js
+++ b/tests/DbaaS/pages/dbaasPage.js
@@ -7,7 +7,6 @@ module.exports = {
   url: 'graph/dbaas',
   disabledDbaaSMessage: {
     textMessage: 'DBaaS is disabled. You can enable it in PMM Settings.',
-    disabledDbaaSPopUpMessage: 'Service dbaas.v1beta1.Components is disabled.',
     settingsLinkLocator: '$settings-link',
     emptyBlock: '$empty-block',
   },

--- a/tests/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/verifyPMMSettingsPageFunctionality_test.js
@@ -106,7 +106,6 @@ Scenario(
     I.dontSeeElement(pmmSettingsPage.fields.dbaasMenuIconLocator);
     I.amOnPage(dbaasPage.url);
     I.waitForElement(dbaasPage.disabledDbaaSMessage.settingsLinkLocator, 30);
-    I.verifyPopUpMessage(dbaasPage.disabledDbaaSMessage.disabledDbaaSPopUpMessage);
     const message = (await I.grabTextFrom(dbaasPage.disabledDbaaSMessage.emptyBlock)).replace(/\s+/g, ' ');
 
     assert.ok(message === dbaasPage.disabledDbaaSMessage.textMessage, `Message Shown on ${message} should be equal to ${dbaasPage.disabledDbaaSMessage.textMessage}`);


### PR DESCRIPTION
Removing check of grafana error Service dbaas.v1beta1.Components is disabled. which is now shown anymore

Test green: https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-ui-tests/detail/pmm2-ui-tests/10821/tests