### PR TITLE
PMM-8866 edited test-case 1070 to verify share link on Home Dashboard for case 449

### DIFF
--- a/tests/pages/dashboardPage.js
+++ b/tests/pages/dashboardPage.js
@@ -168,7 +168,7 @@ module.exports = {
     elements: {
       imageRendererPluginLink: locate('.share-modal-body').find('.external-link'),
     }
-},
+  },
   proxysqlInstanceSummaryDashboard: {
     url: 'graph/d/proxysql-instance-summary/proxysql-instance-summary',
     metrics: [

--- a/tests/verifyMysqlDashboards_test.js
+++ b/tests/verifyMysqlDashboards_test.js
@@ -1,4 +1,10 @@
+const { dashboardPage, homePage } = inject();
 const assert = require('assert');
+
+const urlsAndMetrics = new DataTable(['metricName', 'startUrl']);
+
+urlsAndMetrics.add(['Client Connections (All Host Groups)', `${dashboardPage.proxysqlInstanceSummaryDashboard.url}?from=now-5m&to=now`]);
+urlsAndMetrics.add(['Percona News', homePage.url]);
 
 Feature('Test Dashboards inside the MySQL Folder');
 
@@ -50,14 +56,12 @@ Scenario(
   },
 );
 
-Scenario(
-  'PMM-T1070 - Verify link to instructions for enabling rendering images @nightly @dashboards',
-  async ({ I, dashboardPage, links }) => {
-    const metricName = 'Client Connections (All Host Groups)';
-
-    I.amOnPage(`${dashboardPage.proxysqlInstanceSummaryDashboard.url}?from=now-5m&to=now`);
+Data(urlsAndMetrics).Scenario(
+  'PMM-T1070 + 449 - Verify link to instructions for enabling rendering images @nightly @dashboards',
+  async ({ I, dashboardPage, links, current }) => {
+    I.amOnPage(current.startUrl);
     dashboardPage.waitForDashboardOpened();
-    await dashboardPage.openGraphDropdownMenu(metricName);
+    await dashboardPage.openGraphDropdownMenu(current.metricName);
     const shareLocator = locate('.dropdown-item-text').withText('Share');
 
     I.waitForVisible(shareLocator, 20);

--- a/tests/verifyMysqlDashboards_test.js
+++ b/tests/verifyMysqlDashboards_test.js
@@ -57,7 +57,7 @@ Scenario(
 );
 
 Data(urlsAndMetrics).Scenario(
-  'PMM-T1070 + 449 - Verify link to instructions for enabling rendering images @nightly @dashboards',
+  'PMM-T1070 + PMM-T449 - Verify link to instructions for enabling rendering images @nightly @dashboards',
   async ({ I, dashboardPage, links, current }) => {
     I.amOnPage(current.startUrl);
     dashboardPage.waitForDashboardOpened();


### PR DESCRIPTION
Test case 1070 is the same as test case 449 with the difference only in the start page and the name of the metric. I added the data provider to the 1070 case so as not to duplicate the code.
https://pmm.cd.percona.com/job/pmm2-ui-test-nightly/861/
![image](https://user-images.githubusercontent.com/92315622/146190667-1ec11c67-93fe-414b-9072-d90c304f2163.png)
