### PR TITLE
PMM-9445 Enable MongoDB UI tests

### DIFF
--- a/tests/remoteInstances/remoteInstancesHelper.js
+++ b/tests/remoteInstances/remoteInstancesHelper.js
@@ -12,10 +12,10 @@ const remoteInstanceStatus = {
   },
   mongodb: {
     psmdb_4_2: {
-      enabled: false,
+      enabled: true,
     },
     psmdb_4_4: {
-      enabled: false,
+      enabled: true,
     },
     mongodb_4_4_ssl: {
       enabled: false,


### PR DESCRIPTION
MongoDB tests had been disabled due to issue with MongoDB exporter version used in our test pipeline. Now that it has been fixed, MongoDB related UI tests should be renabled.

Related PRs:
- https://github.com/Percona-Lab/pmm-submodules/pull/2310