### PR TITLE
PMM-9550 added template for new test to verify downloading server diagnostics logs

### DIFF
--- a/pr.codecept.js
+++ b/pr.codecept.js
@@ -13,7 +13,6 @@ exports.config = {
       getPageTimeout: 30000,
       waitForAction: 500,
       pressKeyDelay: 5,
-      FileSystem: {},
       chromium: {
         executablePath: process.env.CHROMIUM_PATH,
         ignoreHTTPSErrors: true,
@@ -54,6 +53,7 @@ exports.config = {
     ChaiWrapper: {
       require: 'codeceptjs-chai',
     },
+    FileSystem: {},
   },
   include: pageObjects,
   multiple: {

--- a/pr.codecept.js
+++ b/pr.codecept.js
@@ -13,6 +13,7 @@ exports.config = {
       getPageTimeout: 30000,
       waitForAction: 500,
       pressKeyDelay: 5,
+      FileSystem: {},
       chromium: {
         executablePath: process.env.CHROMIUM_PATH,
         ignoreHTTPSErrors: true,

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -178,12 +178,12 @@ Scenario(
 
     I.handleDownloads();
     I.click(pmmSettingsPage.fields.diagnosticsButton);
-    I.amInPath('output/downloads');
+    await I.amInPath('output/downloads');
     I.wait(5);
     I.seeFileNameMatching('.zip');
 
-    const downloadedFileNames = I.grabFileNames();
+    const downloadedFileNames = await I.grabFileNames();
 
-    assert.ok(downloadedFileNames.length === 1, `The count of downloaded files must be 1 not ${downloadedFileNames.length}`);
+    assert.ok(downloadedFileNames.length > 0, `The count of downloaded files must be 1 not ${downloadedFileNames.length}`);
   },
 );

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -172,10 +172,10 @@ Scenario(
   'PMM-9550 Verify downloading server diagnostics logs from Settings @settings',
   async ({ I, pmmSettingsPage }) => {
     await pmmSettingsPage.waitForPmmSettingsPageLoaded();
-    I.handleDownloads('downloads/logs');
+    I.handleDownloads();
     I.click(pmmSettingsPage.fields.diagnosticsButton);
-    await I.amInPath('tests/output/downloads');
-    I.seeFileNameMatching('logs');
+    await I.amInPath('tests/output');
+    I.seeFileNameMatching('downloads');
 
     const downloadedFileNames = await I.grabFileNames();
 

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -169,7 +169,7 @@ xScenario(
 );
 
 Scenario(
-  'PMM-9550 Verify downloading server diagnostics logs from Settings @alyona-testing',
+  'PMM-9550 Verify downloading server diagnostics logs from Settings @settings @alyona-testing',
   async ({ I, pmmSettingsPage }) => {
     await pmmSettingsPage.waitForPmmSettingsPageLoaded();
     I.handleDownloads('downloads/logs.zip');

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -1,5 +1,4 @@
 const assert = require("assert");
-const moment = require('moment');
 const page = require('./pages/pmmSettingsPage');
 
 // Value should be in range from 1 to 3650 days, so put a value outside of the range
@@ -173,17 +172,13 @@ Scenario(
   'PMM-9550 Verify downloading server diagnostics logs from Settings @settings',
   async ({ I, pmmSettingsPage }) => {
     await pmmSettingsPage.waitForPmmSettingsPageLoaded();
-
-    const fileName = `pmm-server_${moment().format('YYYY-MM-DD_HH-mm')}.zip`;
-
-    I.handleDownloads();
+    I.handleDownloads('downloads/logs');
     I.click(pmmSettingsPage.fields.diagnosticsButton);
-    await I.amInPath('output/downloads');
-    I.wait(5);
-    I.seeFileNameMatching('.zip');
+    await I.amInPath('tests/output/downloads');
+    I.seeFileNameMatching('logs');
 
     const downloadedFileNames = await I.grabFileNames();
 
-    assert.ok(downloadedFileNames.length > 0, `The count of downloaded files must be 1 not ${downloadedFileNames.length}`);
+    assert.ok(downloadedFileNames.length === 1, `The count of downloaded files must be 1 not ${downloadedFileNames.length}`);
   },
 );

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -169,16 +169,17 @@ xScenario(
 );
 
 Scenario(
-  'PMM-9550 Verify downloading server diagnostics logs from Settings @settings',
+  'PMM-9550 Verify downloading server diagnostics logs from Settings @alyona-testing',
   async ({ I, pmmSettingsPage }) => {
     await pmmSettingsPage.waitForPmmSettingsPageLoaded();
-    I.handleDownloads();
+    I.handleDownloads('downloads/logs.zip');
     I.click(pmmSettingsPage.fields.diagnosticsButton);
-    await I.amInPath('tests/output');
-    I.seeFileNameMatching('downloads');
+    await I.amInPath('tests/output/downloads');
+    await I.waitForFile('logs.zip', 5);
+    await I.seeFileNameMatching('logs.zip');
 
     const downloadedFileNames = await I.grabFileNames();
 
-    assert.ok(downloadedFileNames.length === 1, `The count of downloaded files must be 1 not ${downloadedFileNames.length}`);
+    assert.ok(downloadedFileNames.length === 1, `The Server Diagnostic Zip file should be present inside tests/output/downloads directory, found ${downloadedFileNames.length} files`);
   },
 );

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -1,4 +1,3 @@
-const assert = require("assert");
 const page = require('./pages/pmmSettingsPage');
 
 // Value should be in range from 1 to 3650 days, so put a value outside of the range
@@ -172,14 +171,11 @@ Scenario(
   'PMM-9550 Verify downloading server diagnostics logs from Settings @settings @alyona-testing',
   async ({ I, pmmSettingsPage }) => {
     await pmmSettingsPage.waitForPmmSettingsPageLoaded();
-    I.handleDownloads('downloads/logs.zip');
+    I.handleDownloads('logs.zip');
     I.click(pmmSettingsPage.fields.diagnosticsButton);
-    await I.amInPath('tests/output/downloads');
-    await I.waitForFile('logs.zip', 5);
-    await I.seeFileNameMatching('logs.zip');
-
-    const downloadedFileNames = await I.grabFileNames();
-
-    assert.ok(downloadedFileNames.length === 1, `The Server Diagnostic Zip file should be present inside tests/output/downloads directory, found ${downloadedFileNames.length} files`);
+    await I.amInPath('tests/output');
+    await I.waitForFile('logs.zip', 10);
+    await I.seeFile('logs.zip');
+    await I.seeInThisFile('vmalert.log');
   },
 );

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -1,3 +1,5 @@
+const assert = require("assert");
+const moment = require('moment');
 const page = require('./pages/pmmSettingsPage');
 
 // Value should be in range from 1 to 3650 days, so put a value outside of the range
@@ -164,5 +166,24 @@ xScenario(
 
     await pmmSettingsPage.waitForPmmSettingsPageLoaded();
     I.waitForValue(pmmSettingsPage.fields.dataRetentionCount, dataRetention, 30);
+  },
+);
+
+Scenario(
+  'PMM-9550 Verify downloading server diagnostics logs from Settings @settings',
+  async ({ I, pmmSettingsPage }) => {
+    await pmmSettingsPage.waitForPmmSettingsPageLoaded();
+
+    const fileName = `pmm-server_${moment().format('YYYY-MM-DD_HH-mm')}.zip`;
+
+    I.handleDownloads();
+    I.click(pmmSettingsPage.fields.diagnosticsButton);
+    I.amInPath('output/downloads');
+    I.wait(5);
+    I.seeFileNameMatching('.zip');
+
+    const downloadedFileNames = I.grabFileNames();
+
+    assert.ok(downloadedFileNames.length === 1, `The count of downloaded files must be 1 not ${downloadedFileNames.length}`);
   },
 );

--- a/tests/verifyPMMSettingsPageElements_test.js
+++ b/tests/verifyPMMSettingsPageElements_test.js
@@ -171,9 +171,9 @@ Scenario(
   'PMM-9550 Verify downloading server diagnostics logs from Settings @settings @alyona-testing',
   async ({ I, pmmSettingsPage }) => {
     await pmmSettingsPage.waitForPmmSettingsPageLoaded();
-    I.handleDownloads('logs.zip');
+    I.handleDownloads('downloads/logs.zip');
     I.click(pmmSettingsPage.fields.diagnosticsButton);
-    await I.amInPath('tests/output');
+    await I.amInPath('tests/output/downloads');
     await I.waitForFile('logs.zip', 10);
     await I.seeFile('logs.zip');
     await I.seeInThisFile('vmalert.log');


### PR DESCRIPTION
added new test for verifying downloaded zip-file with logs

https://pmm.cd.percona.com/job/pmm2-ui-test-nightly/1016/
https://pmm.cd.percona.com/view/all/job/pmm2-ui-tests/12164/
![image](https://user-images.githubusercontent.com/92315622/153786461-ec7db0ac-b51a-40b5-9314-d52e36eb31f3.png)
