### PR TITLE
Fix new email service now

### DIFF
--- a/tests/pages/api/portalAPI.js
+++ b/tests/pages/api/portalAPI.js
@@ -22,8 +22,8 @@ module.exports = {
     return {
       name: resp.data.result.account.name,
       id: resp.data.result.account.sys_id,
-      admin1: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('admin-')).email),
-      admin2: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('admin2-')).email),
+      admin1: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('ui_tests_admin-')).email),
+      admin2: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('ui_tests_admin2-')).email),
       technical: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('technical-')).email),
     };
   },

--- a/tests/pages/api/portalAPI.js
+++ b/tests/pages/api/portalAPI.js
@@ -24,7 +24,7 @@ module.exports = {
       id: resp.data.result.account.sys_id,
       admin1: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('ui_tests_admin-')).email),
       admin2: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('ui_tests_admin2-')).email),
-      technical: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('technical-')).email),
+      technical: await this.getUser(resp.data.result.contacts.find(({ email }) => email.startsWith('ui_tests_technical-')).email),
     };
   },
 


### PR DESCRIPTION
We made a change in service now creation, to be able to distinguish ui tests users in logs and okta, this PR handles that change.
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-ui-tests/detail/pmm2-ui-tests/15645/pipeline/