### PR TITLE
PMM-7 Fix for pmm portal upgrade pipeline

### DIFF
--- a/tests/portal/portal_test.js
+++ b/tests/portal/portal_test.js
@@ -28,7 +28,6 @@ Scenario(
       await portalAPI.oktaCreateUser(portalCredentials.technical);
       adminToken = await portalAPI.getUserAccessToken(portalCredentials.admin1.email, portalCredentials.admin1.password);
       org = await portalAPI.apiCreateOrg(adminToken);
-      I.say(portalCredentials.admin1.email);
 
       await portalAPI.apiInviteOrgMember(adminToken, org.id, { username: portalCredentials.admin2.email, role: 'Admin' });
       await portalAPI.apiInviteOrgMember(adminToken, org.id, { username: portalCredentials.technical.email, role: 'Technical' });

--- a/tests/portal/portal_test.js
+++ b/tests/portal/portal_test.js
@@ -28,6 +28,7 @@ Scenario(
       await portalAPI.oktaCreateUser(portalCredentials.technical);
       adminToken = await portalAPI.getUserAccessToken(portalCredentials.admin1.email, portalCredentials.admin1.password);
       org = await portalAPI.apiCreateOrg(adminToken);
+      I.say(portalCredentials.admin1.email);
 
       await portalAPI.apiInviteOrgMember(adminToken, org.id, { username: portalCredentials.admin2.email, role: 'Admin' });
       await portalAPI.apiInviteOrgMember(adminToken, org.id, { username: portalCredentials.technical.email, role: 'Technical' });
@@ -190,7 +191,9 @@ Scenario(
 Scenario(
   'Perform cleanup after PMM upgrade @portal @not-ui-pipeline @post-pmm-portal-upgrade',
   async ({ portalAPI }) => {
-    await portalAPI.apiDeleteOrg(org.id, adminToken);
+    const orgResponse = await portalAPI.apiGetOrg(adminToken);
+
+    await portalAPI.apiDeleteOrg(orgResponse[0].id, adminToken);
     await portalAPI.oktaDeleteUserByEmail(portalCredentials.admin1.email);
     await portalAPI.oktaDeleteUserByEmail(portalCredentials.admin2.email);
     await portalAPI.oktaDeleteUserByEmail(portalCredentials.technical.email);


### PR DESCRIPTION
This PR fixes pmm2-portal-upgrade job, issue was that org id was not define when post upgrade tests were running
pipelines resuls:
https://pmm.cd.percona.com/job/pmm2-upgrade-portal-tests/8/
https://pmm.cd.percona.com/job/pmm2-ui-tests/15871/