### PR TITLE
PMM-7 Fix for deletion of portal users

### DIFF
--- a/tests/pages/api/portalAPI.js
+++ b/tests/pages/api/portalAPI.js
@@ -96,6 +96,11 @@ module.exports = {
   },
 
   async oktaDeleteUserById(userId) {
+    this.oktaDeactivateUserById(userId);
+    this.oktaDeactivateUserById(userId);
+  },
+
+  async oktaDeactivateUserById(userId) {
     const oktaUrl = `${this.oktaUrl}api/v1/users/${userId}`;
     const headers = { Authorization: this.oktaToken };
     const response = await I.sendDeleteRequest(oktaUrl, headers);


### PR DESCRIPTION
Okta call to delete user needs to be made twice to delete user, first call just deactivates user. This PR fixes this issue.