### PR TITLE
PMM-7 fix failing mysql version

### DIFF
--- a/tests/DbaaS/verifyDBaaSPXCCluster_test.js
+++ b/tests/DbaaS/verifyDBaaSPXCCluster_test.js
@@ -4,7 +4,7 @@ const { dbaasAPI, dbaasPage } = inject();
 const clusterName = 'Kubernetes_Testing_Cluster_Minikube';
 const pxc_cluster_name = 'pxc-dbcluster';
 const pxc_cluster_type = 'DB_CLUSTER_TYPE_PXC';
-const mysql_recommended_version = 'MySQL 8.0.25';
+const mysql_recommended_version = 'MySQL 8.0.27';
 
 const pxcDBClusterDetails = new DataTable(['namespace', 'clusterName', 'node']);
 


### PR DESCRIPTION
This fixes all "Expected DB Type was MySQL 8.0.25, but found MySQL 8.0.27" failed tests
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/1344/tests