### PR TITLE
PMM-10531 fix-failing-db-cluster-names

### DIFF
--- a/tests/DbaaS/pages/dbaasActionsPage.js
+++ b/tests/DbaaS/pages/dbaasActionsPage.js
@@ -29,7 +29,6 @@ module.exports = {
     I.waitForEnabled(dbaasPage.tabs.dbClusterTab.dbClusterAddButtonTop, 10);
     I.click(dbaasPage.tabs.dbClusterTab.dbClusterAddButtonTop);
     I.waitForElement(dbaasPage.tabs.dbClusterTab.basicOptions.fields.clusterNameField, 30);
-    I.fillField(dbaasPage.tabs.dbClusterTab.basicOptions.fields.clusterNameField, dbClusterName);
     I.click(dbaasPage.tabs.dbClusterTab.basicOptions.fields.kubernetesClusterDropDown);
     I.waitForElement(
       dbaasPage.tabs.dbClusterTab.basicOptions.fields.kubernetesClusterDropDownSelect(k8sClusterName),
@@ -42,6 +41,8 @@ module.exports = {
       dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseTypeFieldSelect(dbType),
     );
     I.click(dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseTypeFieldSelect(dbType));
+    adminPage.customClearField(dbaasPage.tabs.dbClusterTab.basicOptions.fields.clusterNameField);
+    I.fillField(dbaasPage.tabs.dbClusterTab.basicOptions.fields.clusterNameField, dbClusterName);
 
     if (dbVersion) {
       I.click(dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseVersionField);


### PR DESCRIPTION
All tests containing "Expected the k8s Cluster DB Cluster Name to show pxc-dbcluster-iduf4d but found mysql-rj4oi7" broke after https://jira.percona.com/browse/PMM-10182. This PR replaces the generated cluster names.

before: https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/1429/tests
after: https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/1433/tests