### PR TITLE
PMM-7-fix-failing-delete-pending-clusters

### DIFF
--- a/tests/DbaaS/pages/dbaasActionsPage.js
+++ b/tests/DbaaS/pages/dbaasActionsPage.js
@@ -154,7 +154,7 @@ module.exports = {
     await dbaasAPI.waitForDBClusterState(dbClusterName, k8sClusterName, clusterDBType, 'DB_CLUSTER_STATE_READY');
   },
 
-  async deletePSMDBCluster(dbClusterName, k8sClusterName) {
+  async deletePSMDBCluster(dbClusterName, k8sClusterName, deleteCompleted = true) {
     I.waitForElement(dbaasPage.tabs.dbClusterTab.fields.clusterTableHeader, 30);
     I.click(dbaasPage.tabs.dbClusterTab.fields.clusterActionsMenu);
     await this.checkActionPossible('Delete', true);
@@ -167,7 +167,9 @@ module.exports = {
       dbaasPage.tabs.kubernetesClusterTab.modalContentText,
     );
     I.click(dbaasPage.tabs.dbClusterTab.fields.deleteDBClusterButton);
-    I.waitForElement(dbaasPage.tabs.dbClusterTab.fields.clusterStatusDeleting, 30);
+    if (deleteCompleted) {
+      I.waitForElement(dbaasPage.tabs.dbClusterTab.fields.clusterStatusDeleting, 30);
+    };
     await dbaasAPI.waitForDbClusterDeleted(dbClusterName, k8sClusterName, 'MongoDB');
   },
 

--- a/tests/DbaaS/verifyDBaaSPXCCluster_test.js
+++ b/tests/DbaaS/verifyDBaaSPXCCluster_test.js
@@ -399,17 +399,19 @@ Scenario('Verify update PXC DB Cluster version @dbaas', async ({ I, dbaasPage, d
 
   assert.ok(!version.includes(mysqlVersion), `Expected Version for PXC Cluster After Upgrade ${version} should not be same as Before Update Operation`);
   await dbaasActionsPage.deleteXtraDBCluster(dbClusterRandomName, clusterName);
-
-  Scenario('PMM-T509 Verify Deleting Db Cluster in Pending Status is possible @dbaas',
-    async ({ I, dbaasPage, dbaasActionsPage }) => {
-      const pxc_cluster_pending_delete = 'pxc-pending-delete';
-
-      await dbaasAPI.deleteAllDBCluster(clusterName);
-      await dbaasPage.waitForDbClusterTab(clusterName);
-      I.waitForInvisible(dbaasPage.tabs.kubernetesClusterTab.disabledAddButton, 30);
-      await dbaasActionsPage.createClusterBasicOptions(clusterName, pxc_cluster_pending_delete, 'MySQL');
-      I.click(dbaasPage.tabs.dbClusterTab.createClusterButton);
-      I.waitForText('Processing', 60, dbaasPage.tabs.dbClusterTab.fields.progressBarContent);
-      await dbaasActionsPage.deleteXtraDBCluster(pxc_cluster_pending_delete, clusterName);
-    });
 });
+
+Scenario(
+  'PMM-T509 Verify Deleting Db Cluster in Pending Status is possible @dbaas',
+  async ({ I, dbaasPage, dbaasActionsPage }) => {
+    const pxc_cluster_pending_delete = 'pxc-pending-delete';
+
+    await dbaasAPI.deleteAllDBCluster(clusterName);
+    await dbaasPage.waitForDbClusterTab(clusterName);
+    I.waitForInvisible(dbaasPage.tabs.kubernetesClusterTab.disabledAddButton, 30);
+    await dbaasActionsPage.createClusterBasicOptions(clusterName, pxc_cluster_pending_delete, 'MySQL');
+    I.click(dbaasPage.tabs.dbClusterTab.createClusterButton);
+    I.waitForText('Processing', 60, dbaasPage.tabs.dbClusterTab.fields.progressBarContent);
+    await dbaasActionsPage.deleteXtraDBCluster(pxc_cluster_pending_delete, clusterName);
+  },
+);

--- a/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
+++ b/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
@@ -209,7 +209,7 @@ Scenario('PMM-T509 Verify Deleting Mongo Db Cluster in Pending Status is possibl
     await dbaasActionsPage.createClusterBasicOptions(clusterName, psmdb_cluster_pending_delete, 'MongoDB');
     I.click(dbaasPage.tabs.dbClusterTab.createClusterButton);
     I.waitForText('Processing', 30, dbaasPage.tabs.dbClusterTab.fields.progressBarContent);
-    await dbaasActionsPage.deletePSMDBCluster(psmdb_cluster_pending_delete, clusterName);
+    await dbaasActionsPage.deletePSMDBCluster(psmdb_cluster_pending_delete, clusterName, false);
   }).retry(1);
 
 Scenario('PMM-T704 PMM-T772 PMM-T849 PMM-T850 Resources, PV, Secrets verification @dbaas',


### PR DESCRIPTION
Deleting PSMDB clusters in pending can be too quick (or UI too slow) so the DELETING status won't appear and it's causing failures. This PR fixes it.

https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/1462/tests/