### PR TITLE
PMM-7-fix-pxc-monitoring

### DIFF
--- a/tests/DbaaS/pages/dbaasPage.js
+++ b/tests/DbaaS/pages/dbaasPage.js
@@ -403,12 +403,11 @@ module.exports = {
   },
 
   async pxcClusterMetricCheck(dbclusterName, serviceName, nodeName, haproxynodeName) {
-    await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.pxcGaleraClusterSummaryDashboard.url}&var-cluster=pxc-${dbclusterName}`, 'Last 5 minutes', 4, 0, 2);
     await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.mysqlPXCGaleraNodeSummaryDashboard.url}?&var-service_name=${serviceName}`, 'Last 5 minutes', 4, 0, 2);
     await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.nodeSummaryDashboard.url}?&var-node_name=${nodeName}`, 'Last 5 minutes', 4, 0, 1);
     // eslint-disable-next-line no-inline-comments
     await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.mysqlInstanceSummaryDashboard.url}&var-service_name=${serviceName}`, 'Last 5 minutes', 4, 1, 5); //FIXME: Expected with N/A should be 0 after PMM-10308 is fixed
-    await dashboardPage.genericDashboardLoadForDbaaSClusters(`graph/d/haproxy-instance-summary/haproxy-instance-summary?orgId=1&refresh=1m&var-node_name=${haproxynodeName}`, 'Last 5 minutes', 4, 0, 3);
+    await dashboardPage.genericDashboardLoadForDbaaSClusters(`graph/d/haproxy-instance-summary/haproxy-instance-summary?orgId=1&refresh=1m&var-service_name=${haproxynodeName}`, 'Last 5 minutes', 4, 0, 3);
   },
 
   async psmdbClusterMetricCheck(dbclusterName, serviceName, nodeName) {
@@ -422,7 +421,6 @@ module.exports = {
   async dbaasQANCheck(dbclusterName, nodeName, serviceName) {
     I.amOnPage(I.buildUrlWithParams(qanPage.clearUrl, { from: 'now-3h' }));
     qanOverview.waitForOverviewLoaded();
-    qanFilters.checkFilterExistInSection('Cluster', dbclusterName);
     qanFilters.checkFilterExistInSection('Node Name', `${nodeName}`);
     qanFilters.checkFilterExistInSection('Service Name', `${serviceName}`);
     qanOverview.waitForOverviewLoaded();

--- a/tests/DbaaS/pages/dbaasPage.js
+++ b/tests/DbaaS/pages/dbaasPage.js
@@ -193,7 +193,7 @@ module.exports = {
     },
   },
   clusterDashboardUrls: {
-    pxcDashboard: (dbClusterName) => `/graph/d/pxc-cluster-summary/pxc-galera-cluster-summary?orgId=1&var-cluster=${dbClusterName}-pxc`,
+    pxcDashboard: (dbClusterName) => `/graph/d/pxc-cluster-summary/pxc-galera-cluster-summary?var-cluster=${dbClusterName}-pxc`,
     psmdbDashboard: (dbClusterName) => `/graph/d/mongodb-cluster-summary/mongodb-cluster-summary?var-cluster=${dbClusterName}`,
   },
 
@@ -403,11 +403,11 @@ module.exports = {
   },
 
   async pxcClusterMetricCheck(dbclusterName, serviceName, nodeName, haproxynodeName) {
-    await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.mysqlPXCGaleraNodeSummaryDashboard.url}?&var-service_name=${serviceName}`, 'Last 5 minutes', 4, 0, 2);
-    await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.nodeSummaryDashboard.url}?&var-node_name=${nodeName}`, 'Last 5 minutes', 4, 0, 1);
+    await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.mysqlPXCGaleraNodeSummaryDashboard.url}?&var-service_name=${serviceName}`, 'Last 15 minutes', 4, 0, 2);
+    await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.nodeSummaryDashboard.url}?&var-node_name=${nodeName}`, 'Last 15 minutes', 4, 0, 1);
     // eslint-disable-next-line no-inline-comments
-    await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.mysqlInstanceSummaryDashboard.url}&var-service_name=${serviceName}`, 'Last 5 minutes', 4, 1, 5); //FIXME: Expected with N/A should be 0 after PMM-10308 is fixed
-    await dashboardPage.genericDashboardLoadForDbaaSClusters(`graph/d/haproxy-instance-summary/haproxy-instance-summary?orgId=1&refresh=1m&var-service_name=${haproxynodeName}`, 'Last 5 minutes', 4, 0, 3);
+    await dashboardPage.genericDashboardLoadForDbaaSClusters(`${dashboardPage.mysqlInstanceSummaryDashboard.url}&var-service_name=${serviceName}`, 'Last 15 minutes', 4, 1, 5); //FIXME: Expected with N/A should be 0 after PMM-10308 is fixed
+    await dashboardPage.genericDashboardLoadForDbaaSClusters(`graph/d/haproxy-instance-summary/haproxy-instance-summary?orgId=1&refresh=1m&var-service_name=${haproxynodeName}`, 'Last 15 minutes', 4, 0, 3);
   },
 
   async psmdbClusterMetricCheck(dbclusterName, serviceName, nodeName) {

--- a/tests/DbaaS/pages/dbaasPage.js
+++ b/tests/DbaaS/pages/dbaasPage.js
@@ -193,7 +193,7 @@ module.exports = {
     },
   },
   clusterDashboardUrls: {
-    pxcDashboard: (dbClusterName) => `/graph/d/pxc-cluster-summary/pxc-galera-cluster-summary?var-cluster=${dbClusterName}-pxc`,
+    pxcDashboard: (dbClusterName) => `/graph/d/pxc-cluster-summary/pxc-galera-cluster-summary?orgId=1&var-cluster=${dbClusterName}-pxc`,
     psmdbDashboard: (dbClusterName) => `/graph/d/mongodb-cluster-summary/mongodb-cluster-summary?var-cluster=${dbClusterName}`,
   },
 

--- a/tests/DbaaS/verifyDBaaSPXCCluster_test.js
+++ b/tests/DbaaS/verifyDBaaSPXCCluster_test.js
@@ -57,24 +57,13 @@ async ({
   await dbaasPage.verifyLogPopup(18);
 });
 
-Scenario('PMM-T459, PMM-T473, PMM-T478, PMM-T524 Verify DB Cluster Details are listed, shortcut link for DB Cluster, Show/Hide password button @dbaas',
+Scenario('PMM-T582 Verify Adding Cluster with Same Name and Same DB Type @dbaas',
   async ({ I, dbaasPage, dbaasActionsPage }) => {
-    const clusterDetails = {
-      clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.pxcDashboard(pxc_cluster_name),
-      dbType: mysql_recommended_version,
-      memory: '2 GB',
-      cpu: '1',
-      disk: '25 GB',
-    };
-
     await dbaasPage.waitForDbClusterTab(clusterName);
-    I.waitForVisible(dbaasPage.tabs.dbClusterTab.fields.clusterTableHeader, 30);
-    await dbaasPage.validateClusterDetail(pxc_cluster_name, clusterName, clusterDetails,
-      clusterDetails.clusterDashboardRedirectionLink);
-    await dbaasActionsPage.restartCluster(pxc_cluster_name, clusterName, 'MySQL');
-    await dbaasPage.validateClusterDetail(pxc_cluster_name, clusterName, clusterDetails,
-      clusterDetails.clusterDashboardRedirectionLink);
-  });
+    await dbaasActionsPage.createClusterBasicOptions(clusterName, pxc_cluster_name, 'MySQL');
+    I.click(dbaasPage.tabs.dbClusterTab.createClusterButton);
+    await dbaasPage.seeErrorForAddedDBCluster(pxc_cluster_name);
+});
 
 Scenario(
   'PMM-T502 Verify monitoring of PXC cluster @dbaas',
@@ -103,13 +92,37 @@ Data(pxcDBClusterDetails).Scenario(
   },
 );
 
-Scenario('PMM-T582 Verify Adding Cluster with Same Name and Same DB Type @dbaas',
+Scenario(
+'PMM-T459 Verify DB Cluster Details are listed '
+    + 'PMM-T473 Verify shortcut link for DB Clusters '
+    + 'PMM-T478 Verify Hide Password button on DB cluster page '
+    + 'PMM-T485 Verify user can restart Percona PXC cluster @dbaas',
   async ({ I, dbaasPage, dbaasActionsPage }) => {
+    const clusterDetails = {
+      clusterDashboardRedirectionLink: dbaasPage.clusterDashboardUrls.pxcDashboard(pxc_cluster_name),
+      dbType: mysql_recommended_version,
+      memory: '2 GB',
+      cpu: '1',
+      disk: '25 GB',
+    };
+
     await dbaasPage.waitForDbClusterTab(clusterName);
-    await dbaasActionsPage.createClusterBasicOptions(clusterName, pxc_cluster_name, 'MySQL');
-    I.click(dbaasPage.tabs.dbClusterTab.createClusterButton);
-    await dbaasPage.seeErrorForAddedDBCluster(pxc_cluster_name);
-  });
+    I.waitForVisible(dbaasPage.tabs.dbClusterTab.fields.clusterTableHeader, 30);
+    await dbaasPage.validateClusterDetail(
+      pxc_cluster_name,
+      clusterName,
+      clusterDetails,
+      clusterDetails.clusterDashboardRedirectionLink,
+    );
+    await dbaasActionsPage.restartCluster(pxc_cluster_name, clusterName, 'MySQL');
+    await dbaasPage.validateClusterDetail(
+      pxc_cluster_name,
+      clusterName,
+      clusterDetails,
+      clusterDetails.clusterDashboardRedirectionLink,
+    );
+  },
+);
 
 Scenario('PMM-T460, PMM-T452 Verify force unregistering Kubernetes cluster @dbaas',
   async ({ I, dbaasPage }) => {

--- a/tests/DbaaS/verifyDBaaSPXCCluster_test.js
+++ b/tests/DbaaS/verifyDBaaSPXCCluster_test.js
@@ -82,7 +82,7 @@ Scenario(
     await dbaasPage.waitForDbClusterTab(clusterName);
     I.waitForVisible(dbaasPage.tabs.dbClusterTab.dbClusterAddButtonTop, 30);
     await dashboardPage.genericDashboardLoadForDbaaSClusters(
-      `${dashboardPage.pxcGaleraClusterSummaryDashboard.url}&var-cluster=pxc-dbcluster-test-pxc`, 'Last 15 minutes', 4, 0, 2); //todo
+      `${dashboardPage.pxcGaleraClusterSummaryDashboard.url}&var-cluster=${pxc_cluster_name}-pxc`, 'Last 15 minutes', 4, 0, 2);
     I.amOnPage(I.buildUrlWithParams(qanPage.clearUrl, { from: 'now-3h' }));
     qanOverview.waitForOverviewLoaded();
     qanFilters.checkFilterExistInSection('Cluster', pxc_cluster_name);

--- a/tests/DbaaS/verifyDBaaSPXCCluster_test.js
+++ b/tests/DbaaS/verifyDBaaSPXCCluster_test.js
@@ -76,10 +76,22 @@ Scenario('PMM-T459, PMM-T473, PMM-T478, PMM-T524 Verify DB Cluster Details are l
       clusterDetails.clusterDashboardRedirectionLink);
   });
 
-Data(pxcDBClusterDetails).Scenario('PMM-T502, Verify Monitoring of PXC Clusters @dbaas',
-  async ({
-    I, dbaasPage, current,
-  }) => {
+Scenario(
+  'PMM-T502 Verify monitoring of PXC cluster @dbaas',
+  async ({ I, dbaasPage, dashboardPage, qanFilters, qanPage, qanOverview }) => {
+    await dbaasPage.waitForDbClusterTab(clusterName);
+    I.waitForVisible(dbaasPage.tabs.dbClusterTab.dbClusterAddButtonTop, 30);
+    await dashboardPage.genericDashboardLoadForDbaaSClusters(
+      `${dashboardPage.pxcGaleraClusterSummaryDashboard.url}&var-cluster=pxc-dbcluster-test-pxc`, 'Last 15 minutes', 4, 0, 2); //todo
+    I.amOnPage(I.buildUrlWithParams(qanPage.clearUrl, { from: 'now-3h' }));
+    qanOverview.waitForOverviewLoaded();
+    qanFilters.checkFilterExistInSection('Cluster', pxc_cluster_name);
+  },
+);
+
+Data(pxcDBClusterDetails).Scenario(
+  'PMM-T502 Verify monitoring of PXC service and node @dbaas',
+  async ({ I, dbaasPage, current }) => {
     await dbaasPage.waitForDbClusterTab(clusterName);
     I.waitForVisible(dbaasPage.tabs.dbClusterTab.dbClusterAddButtonTop, 30);
     const serviceName = `${current.namespace}-${current.clusterName}-pxc-${current.node}`;
@@ -88,7 +100,8 @@ Data(pxcDBClusterDetails).Scenario('PMM-T502, Verify Monitoring of PXC Clusters 
     await dbaasPage.pxcClusterMetricCheck(pxc_cluster_name, serviceName, serviceName, haproxyNodeName);
     await dbaasPage.dbaasQANCheck(pxc_cluster_name, serviceName, serviceName);
     await dbaasPage.dbClusterAgentStatusCheck(pxc_cluster_name, serviceName, 'MYSQL_SERVICE');
-  });
+  },
+);
 
 Scenario('PMM-T582 Verify Adding Cluster with Same Name and Same DB Type @dbaas',
   async ({ I, dbaasPage, dbaasActionsPage }) => {

--- a/tests/pages/dashboardPage.js
+++ b/tests/pages/dashboardPage.js
@@ -220,7 +220,7 @@ module.exports = {
     ],
   },
   pxcGaleraClusterSummaryDashboard: {
-    url: 'graph/d/pxc-cluster-summary/pxc-galera-cluster-summary',
+    url: 'graph/d/pxc-cluster-summary/pxc-galera-cluster-summary?orgId=1&',
     metrics: [
       'Percona XtraDB / Galera Cluster Size',
       'Flow Control Paused Time',


### PR DESCRIPTION
Test were failing randomly because some metrics might not have been available in selected time range for second or third run.

Tests using "cluster" filter were moved to a separate scenario - they need to be run only once (there's only one cluster) not three times as it was before.

https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/1480/tests