### PR TITLE
Revert "PMM-10881 Change "Edit folder" to "Go to folder""

### DIFF
--- a/tests/ia/alertRules_test.js
+++ b/tests/ia/alertRules_test.js
@@ -61,7 +61,7 @@ Scenario(
     });
     const folderUID = await rulesAPI.getFolderUID(ruleFolder);
 
-    I.seeElement(alertRulesPage.buttons.goToFolderButton(folderUID, ruleFolder.toLowerCase()));
+    I.seeElement(alertRulesPage.buttons.editFolderButton(folderUID, ruleFolder.toLowerCase()));
     I.seeElement(alertRulesPage.buttons.managePermissionsButton(folderUID, ruleFolder.toLowerCase()));
     I.seeElement(alertRulesPage.elements.totalRulesCounter('1 rule', ruleFolder));
     await rulesAPI.removeAlertRule(ruleFolder);

--- a/tests/ia/pages/alertRulesPage.js
+++ b/tests/ia/pages/alertRulesPage.js
@@ -36,7 +36,7 @@ module.exports = {
     deleteAlertRule: locate('span').withText('Delete').inside('button'),
     groupCollapseButton: (folderText) =>  `//button[@data-testid='group-collapse-toggle'][following::h6[contains(., '${folderText}')]]`,
     ruleCollapseButton: `button[aria-label='Expand row']`,
-    goToFolderButton: (folderID, folderText) => locate('[aria-label="go to folder"]').withAttr({ 'href': `/graph/dashboards/f/${folderID}/${folderText}` }),
+    editFolderButton: (folderID, folderText)  => locate('[aria-label="edit folder"]').withAttr({ 'href': `/graph/dashboards/f/${folderID}/${folderText}/settings` }),
     managePermissionsButton: (folderID, folderText)  => locate('[aria-label="manage permissions"]').withAttr({ 'href': `/graph/dashboards/f/${folderID}/${folderText}/permissions` }),
     confirmModal: `button[aria-label='Confirm Modal Danger Button']`,
     cancelModal: locate('button').withText('Cancel'),


### PR DESCRIPTION
Reverts percona/pmm-ui-tests#453

Merged too soon and is blocking other PRs.

Currently there's another UI test that is block the grafana update. (Locally all tests pass, on CI if fails)