### PR TITLE
PMM-11428-broken-edit-page-fix

### DIFF
--- a/tests/DbaaS/pages/dbaasPage.js
+++ b/tests/DbaaS/pages/dbaasPage.js
@@ -174,11 +174,6 @@ module.exports = {
         addNewSourceRangeButton: locate('button').find('span').withText('Add new').as('Add Source Range button'),
         sourceRangeInput: locate('input').withAttr({ placeholder: '181.170.213.40/32' }).as('Source Range input'),
         deleteSourceRangeButton: (order) => `$deleteButton-${order}`,
-        disabled: {
-          exposeCheckboxDisabled: '//input[@data-testid="expose-checkbox-input" and @disabled]',
-          internetFacingCheckboxDisabled: '//input[@data-testid="internetFacing-checkbox-input" and @disabled]',
-          addNewSourceRangeButtonDisabled: `//button[(@disabled)]//span[contains(., 'Add new')]`,
-        },
       },
       fields: {
         clusterDetailHeaders: ['Name', 'Database', 'Connection', 'DB Cluster Parameters', 'Cluster Status', 'Actions'],

--- a/tests/DbaaS/pages/dbaasPage.js
+++ b/tests/DbaaS/pages/dbaasPage.js
@@ -173,7 +173,7 @@ module.exports = {
         sourceRangesLabel: locate('label').withText('Source Range'),
         addNewSourceRangeButton: locate('button').find('span').withText('Add new').as('Add Source Range button'),
         sourceRangeInput: locate('input').withAttr({ placeholder: '181.170.213.40/32' }).as('Source Range input'),
-        deleteSourceRangeButton: locate('$network-and-security').find('button').at(2).as('Delete Source Range button'),
+        deleteSourceRangeButton: (order) => `$deleteButton-${order}`,
         disabled: {
           exposeCheckboxDisabled: '//input[@data-testid="expose-checkbox-input" and @disabled]',
           internetFacingCheckboxDisabled: '//input[@data-testid="internetFacing-checkbox-input" and @disabled]',
@@ -517,5 +517,11 @@ module.exports = {
     } else {
       I.dontSee(`${dbClusterType}-${dbClusterName}`, dbaasPage.apiKeysPage.apiKeysTable);
     }
+  },
+
+  async verifySourceRangeCount(count) {
+    let sourceRange = await I.grabNumberOfVisibleElements(this.tabs.dbClusterTab.networkAndSecurity.sourceRangeInput);
+
+    assert.ok(sourceRange === count, `There should be ${count} Source Range Inputs but found ${sourceRange}`);
   },
 };

--- a/tests/DbaaS/verifyDBaaSPXCCluster_test.js
+++ b/tests/DbaaS/verifyDBaaSPXCCluster_test.js
@@ -69,7 +69,6 @@ Scenario('PMM-T1577 Verify Edit DB Cluster page @dbaas',
     I.seeElement(dbaasPage.tabs.dbClusterTab.advancedOptions.fields.advancedSettingsLabel);
     I.seeElement(dbaasPage.tabs.dbClusterTab.dbConfigurations.configurationsHeader('MySQL'));
     I.seeElement(dbaasPage.tabs.dbClusterTab.networkAndSecurity.networkAndSecurityHeader);
-    await dbaasPage.verifyElementsInSection(dbaasPage.tabs.dbClusterTab.networkAndSecurity.disabled);
     I.seeElement(dbaasPage.tabs.dbClusterTab.editClusterButtonDisabled);
   }
 );

--- a/tests/DbaaS/verifyDBaaS_test.js
+++ b/tests/DbaaS/verifyDBaaS_test.js
@@ -390,17 +390,14 @@ Scenario('PMM-T1571 Verify Create DB Cluster page @dbaas',
     I.seeElement(dbaasPage.tabs.dbClusterTab.networkAndSecurity.internetFacingLabel);
     I.scrollTo(dbaasPage.tabs.dbClusterTab.networkAndSecurity.sourceRangesLabel);
     I.click(dbaasPage.tabs.dbClusterTab.networkAndSecurity.addNewSourceRangeButton);
-    let sourceRange = await I.grabNumberOfVisibleElements(
-      dbaasPage.tabs.dbClusterTab.networkAndSecurity.sourceRangeInput);
-
-    assert.ok(sourceRange === 2, `There should be 2 Source Range Inputs but found ${sourceRange}`);
-
-    I.click(dbaasPage.tabs.dbClusterTab.networkAndSecurity.deleteSourceRangeButton);
-
-    sourceRange = await I.grabNumberOfVisibleElements(dbaasPage.tabs.dbClusterTab.networkAndSecurity.sourceRangeInput);
-
-    assert.ok(sourceRange === 1, `There should be 1 Source Range Input but found ${sourceRange}`);
-
+    I.click(dbaasPage.tabs.dbClusterTab.networkAndSecurity.addNewSourceRangeButton);
+    await dbaasPage.verifySourceRangeCount(3);
+    I.click(dbaasPage.tabs.dbClusterTab.networkAndSecurity.deleteSourceRangeButton(2));
+    await dbaasPage.verifySourceRangeCount(2);
+    I.click(dbaasPage.tabs.dbClusterTab.networkAndSecurity.deleteSourceRangeButton(1));
+    await dbaasPage.verifySourceRangeCount(1);
+    I.click(dbaasPage.tabs.dbClusterTab.networkAndSecurity.deleteSourceRangeButton(0));
+    await dbaasPage.verifySourceRangeCount(1);
     I.click(dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseTypeField);
     I.fillField(dbaasPage.tabs.dbClusterTab.basicOptions.fields.dbClusterDatabaseTypeInputField, 'MongoDB');
     I.waitForElement(

--- a/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
+++ b/tests/DbaaS/verifyDbaaSMongoDBCluster_test.js
@@ -121,7 +121,6 @@ Scenario('PMM-T1577 Verify Edit DB Cluster page @dbaas',
     I.seeElement(dbaasPage.tabs.dbClusterTab.advancedOptions.fields.advancedSettingsLabel);
     I.seeElement(dbaasPage.tabs.dbClusterTab.dbConfigurations.configurationsHeader('MongoDB'));
     I.seeElement(dbaasPage.tabs.dbClusterTab.networkAndSecurity.networkAndSecurityHeader);
-    await dbaasPage.verifyElementsInSection(dbaasPage.tabs.dbClusterTab.networkAndSecurity.disabled);
     I.seeElement(dbaasPage.tabs.dbClusterTab.editClusterButtonDisabled);
   }
 );  


### PR DESCRIPTION
This PR fixes test cases PMM-T1571 and PMM-T1577
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/2358/tests

- removing disabled elements because they are not on edit page anymore,
- changing source range count behaviour