### PR TITLE
PMM-11640 backup management enabled by default

### DIFF
--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -1,8 +1,7 @@
 const { pmmSettingsPage } = inject();
+const { homePage } = inject();
 const communicationDefaults = new DataTable(['type', 'serverAddress', 'hello', 'from', 'authType', 'username', 'password', 'url', 'message']);
 const assert = require('assert');
-
-const homePage = inject();
 
 // pmmSettingsPage.communicationData.forEach(({
 //   type, serverAddress, hello, from, authType, username, password, url,
@@ -364,7 +363,7 @@ Scenario(
     I.assertEqual(settingEndpointResponse, true);
     I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
     I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
-    pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');
+    await pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');
     assert.ok(settingEndpointResponse, `Backup managment should be turned on by default from 2.36.0 release but found ${settingEndpointResponse}`);
   },
 ).retry(2);

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -350,7 +350,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-11640-backup-managment-enabled-by-default @backup',
+  'PMM-T1658-backup-managment-enabled-by-default @backup',
   async ({
     I, pmmSettingsPage, settingsAPI,
   }) => {

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -350,7 +350,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T1658-backup-managment-enabled-by-default @backup',
+  'PMM-T1658-backup-managment-enabled-by-default @backup @bm-fb',
   async ({
     I, pmmSettingsPage, settingsAPI, homePage,
   }) => {

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -354,13 +354,9 @@ Scenario(
   async ({
     I, pmmSettingsPage, settingsAPI,
   }) => {
-    // const serverAddressIP = process.env.VM_IP;
-    // const settingsEndpoint = `https://${serverAddressIP}v1/Settings/Get`;
-    // const response = await I.sendGetRequest(settingsEndpoint);
-    // const jsonResponse = response.data;
-    const settingEndpointResponse = settingsAPI.getSettings();
+    const settingEndpointResponse = await settingsAPI.getSettings('backup_management_enabled');
 
-    I.assertEqual(settingEndpointResponse['backup management'], 'true');
+    I.assertEqual(settingEndpointResponse, true);
     I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
     I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
     pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -350,7 +350,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-11640-backup-managment-enabled-by-default @backup @nightly',
+  'PMM-11640-backup-managment-enabled-by-default @backup',
   async ({
     I, pmmSettingsPage, settingsAPI,
   }) => {

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -355,16 +355,22 @@ Scenario(
   async ({
     I, pmmSettingsPage, settingsAPI, homePage,
   }) => {
+    const pmmVersion = await homePage.getVersions().versionMinor;
+
     const settingEndpointResponse = await settingsAPI.getSettings('backup_management_enabled');
     const bmIcon = locate('a[type="button"][aria-label="Backup"]');
 
-    I.amOnPage(homePage.url);
-    I.waitForElement(bmIcon, 30);
-    I.assertEqual(settingEndpointResponse, true);
-    I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
-    I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
-    await pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');
-    assert.ok(settingEndpointResponse, `Backup managment should be turned on by default from 2.36.0 release but found ${settingEndpointResponse}`);
+    if (pmmVersion >= 36 || pmmVersion === undefined) {
+      I.amOnPage(homePage.url);
+      I.waitForElement(bmIcon, 30);
+      I.assertEqual(settingEndpointResponse, true);
+      I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
+      I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
+      await pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');
+      assert.ok(settingEndpointResponse, `Backup managment should be turned on by default from 2.36.0 release but found ${settingEndpointResponse}`);
+    } else {
+      I.say('Skipping this test because PMM Server version is lower then Feature fix version');
+    }
   },
 ).retry(2);
 

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -314,7 +314,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T841 - Verify user is able to enable Backup Management @backup',
+  '@PMM-T1658 Verify that backup management is enabled by default @backup @bm-fb',
   async ({
     I, pmmSettingsPage, scheduledPage, settingsAPI, codeceptjsConfig,
   }) => {
@@ -350,7 +350,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T1658-backup-managment-enabled-by-default @backup @bm-fb',
+  '@PMM-T1658 Verify that backup management is enabled by default @backup @bm-fb',
   async ({
     I, pmmSettingsPage, settingsAPI, homePage,
   }) => {

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -1,6 +1,5 @@
 const communicationDefaults = new DataTable(['type', 'serverAddress', 'hello', 'from', 'authType', 'username', 'password', 'url', 'message']);
 const assert = require('assert');
-const leftNavMenu = require('../pages/leftNavMenu');
 
 // pmmSettingsPage.communicationData.forEach(({
 //   type, serverAddress, hello, from, authType, username, password, url,
@@ -352,7 +351,7 @@ Scenario(
 Scenario(
   '@PMM-T1658 Verify that backup management is enabled by default @backup @bm-fb',
   async ({
-    I, pmmSettingsPage, settingsAPI, homePage,
+    I, pmmSettingsPage, settingsAPI, homePage, leftNavMenu,
   }) => {
     const pmmVersion = await homePage.getVersions().versionMinor;
 

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -1,5 +1,3 @@
-const { pmmSettingsPage } = inject();
-const { homePage } = inject();
 const communicationDefaults = new DataTable(['type', 'serverAddress', 'hello', 'from', 'authType', 'username', 'password', 'url', 'message']);
 const assert = require('assert');
 const leftNavMenu = require('../pages/leftNavMenu');

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -1,6 +1,8 @@
 const { pmmSettingsPage } = inject();
 const communicationDefaults = new DataTable(['type', 'serverAddress', 'hello', 'from', 'authType', 'username', 'password', 'url', 'message']);
 const assert = require('assert');
+const { homeDashboard } = require('../pages/dashboardPage');
+const homePage = require('../pages/homePage');
 
 // pmmSettingsPage.communicationData.forEach(({
 //   type, serverAddress, hello, from, authType, username, password, url,
@@ -352,14 +354,18 @@ Scenario(
 Scenario(
   'PMM-T1658-backup-managment-enabled-by-default @backup',
   async ({
-    I, pmmSettingsPage, settingsAPI,
+    I, pmmSettingsPage, settingsAPI, homePage,
   }) => {
     const settingEndpointResponse = await settingsAPI.getSettings('backup_management_enabled');
+    const bmIcon = locate('a[type="button"][aria-label="Backup"]');
 
+    I.amOnPage(homePage.url);
+    I.waitForElement(bmIcon, 30);
     I.assertEqual(settingEndpointResponse, true);
     I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
     I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
     pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');
+    assert.ok(settingEndpointResponse, `Backup managment should be turned on by default from 2.36.0 release but found ${settingEndpointResponse}`);
   },
 ).retry(2);
 

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -352,14 +352,15 @@ Scenario(
 Scenario(
   'PMM-11640-backup-managment-enabled-by-default @backup @nightly',
   async ({
-    I, pmmSettingsPage, portalAPI, perconaPlatformPage, settingsAPI,
+    I, pmmSettingsPage, settingsAPI,
   }) => {
-    const serverAddressIP = process.env.VM_IP;
-    const settingsEndpoint = `https://${serverAddressIP}v1/Settings/Get`;
-    const response = await I.sendGetRequest(settingsEndpoint);
-    const jsonResponse = response.data;
+    // const serverAddressIP = process.env.VM_IP;
+    // const settingsEndpoint = `https://${serverAddressIP}v1/Settings/Get`;
+    // const response = await I.sendGetRequest(settingsEndpoint);
+    // const jsonResponse = response.data;
+    const settingEndpointResponse = settingsAPI.getSettings();
 
-    I.assertEqual(jsonResponse['backup management'], 'true');
+    I.assertEqual(settingEndpointResponse['backup management'], 'true');
     I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
     I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
     pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -360,7 +360,7 @@ Scenario(
 
     if (pmmVersion >= 36 || pmmVersion === undefined) {
       I.amOnPage(homePage.url);
-      I.waitForElement(leftNavMenu.backups.locator, 30);
+      I.waitForVisible(leftNavMenu.backups.locator, 30);
       I.assertEqual(settingEndpointResponse, true);
       I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
       I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -348,6 +348,24 @@ Scenario(
     scheduledPage.openScheduledBackupsPage();
   },
 );
+
+Scenario(
+  'PMM-11640-backup-managment-enabled-by-default @backup @nightly',
+  async ({
+    I, pmmSettingsPage, portalAPI, perconaPlatformPage, settingsAPI,
+  }) => {
+    const serverAddressIP = process.env.VM_IP;
+    const settingsEndpoint = `https://${serverAddressIP}v1/Settings/Get`;
+    const response = await I.sendGetRequest(settingsEndpoint);
+    const jsonResponse = response.data;
+
+    I.assertEqual(jsonResponse['backup management'], 'true');
+    I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
+    I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
+    pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');
+  },
+).retry(2);
+
 Scenario(
   'PMM-T1328 Verify public address is set automatically on Percona Platform page once connected to Portal @nightly',
   async ({

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -1,8 +1,8 @@
 const { pmmSettingsPage } = inject();
 const communicationDefaults = new DataTable(['type', 'serverAddress', 'hello', 'from', 'authType', 'username', 'password', 'url', 'message']);
 const assert = require('assert');
-const { homeDashboard } = require('../pages/dashboardPage');
-const homePage = require('../pages/homePage');
+
+const homePage = inject();
 
 // pmmSettingsPage.communicationData.forEach(({
 //   type, serverAddress, hello, from, authType, username, password, url,

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -314,7 +314,7 @@ Scenario(
 );
 
 Scenario(
-  '@PMM-T1658 Verify that backup management is enabled by default @backup @bm-fb',
+  'PMM-T841 - Verify user is able to enable Backup Management @backup',
   async ({
     I, pmmSettingsPage, scheduledPage, settingsAPI, codeceptjsConfig,
   }) => {

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -2,6 +2,7 @@ const { pmmSettingsPage } = inject();
 const { homePage } = inject();
 const communicationDefaults = new DataTable(['type', 'serverAddress', 'hello', 'from', 'authType', 'username', 'password', 'url', 'message']);
 const assert = require('assert');
+const leftNavMenu = require('../pages/leftNavMenu');
 
 // pmmSettingsPage.communicationData.forEach(({
 //   type, serverAddress, hello, from, authType, username, password, url,
@@ -358,18 +359,17 @@ Scenario(
     const pmmVersion = await homePage.getVersions().versionMinor;
 
     const settingEndpointResponse = await settingsAPI.getSettings('backup_management_enabled');
-    const bmIcon = locate('a[type="button"][aria-label="Backup"]');
 
     if (pmmVersion >= 36 || pmmVersion === undefined) {
       I.amOnPage(homePage.url);
-      I.waitForElement(bmIcon, 30);
+      I.waitForElement(leftNavMenu.backups.locator, 30);
       I.assertEqual(settingEndpointResponse, true);
       I.amOnPage(pmmSettingsPage.advancedSettingsUrl);
       I.waitForVisible(pmmSettingsPage.fields.backupManagementSwitch, 30);
       await pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.backupManagementSwitchInput, 'on');
       assert.ok(settingEndpointResponse, `Backup managment should be turned on by default from 2.36.0 release but found ${settingEndpointResponse}`);
     } else {
-      I.say('Skipping this test because PMM Server version is lower then Feature fix version');
+      I.say('Skipping this test PMM-T1658, because PMM Server version is lower then Feature fix version');
     }
   },
 ).retry(2);

--- a/tests/pages/leftNavMenu.js
+++ b/tests/pages/leftNavMenu.js
@@ -102,7 +102,12 @@ module.exports = {
       configurationAdvisors: menuOption(ad, 'Configuration Advisors', '/graph/advisors/configuration'),
       securityAdvisors: menuOption(ad, 'Security Advisors', '/graph/advisors/security'),
     }),
-  backups: new LeftMenu('Backup', '/graph/backup'),
+  backups: new LeftMenu('Backup', '/graph/backup/inventory', {
+    allBackups: menuOption(bm, 'Tab All Backups', '/graph/backup/inventory'),
+    scheduledBackupJobs: menuOption(bm, 'Tab Scheduled Backup Jobs', '/graph/backup/scheduled'),
+    restores: menuOption(bm, 'Tab Restores', '/graph/backup/restore'),
+    storageLocations: menuOption(bm, 'Tab Storage Locations', '/graph/backup/locations'),
+  }),
   configuration: new LeftMenu('Configuration', '/graph/inventory/services',
     {
       serviceAccounts: menuOption(co, 'Service accounts', '/graph/org/serviceaccounts'),

--- a/tests/pages/leftNavMenu.js
+++ b/tests/pages/leftNavMenu.js
@@ -103,10 +103,10 @@ module.exports = {
       securityAdvisors: menuOption(ad, 'Security Advisors', '/graph/advisors/security'),
     }),
   backups: new LeftMenu('Backup', '/graph/backup/inventory', {
-    allBackups: menuOption(bm, 'Tab All Backups', '/graph/backup/inventory'),
-    scheduledBackupJobs: menuOption(bm, 'Tab Scheduled Backup Jobs', '/graph/backup/scheduled'),
-    restores: menuOption(bm, 'Tab Restores', '/graph/backup/restore'),
-    storageLocations: menuOption(bm, 'Tab Storage Locations', '/graph/backup/locations'),
+    allBackups: menuOption(bm, 'All Backups', '/graph/backup/inventory'),
+    scheduledBackupJobs: menuOption(bm, 'Scheduled Backup Jobs', '/graph/backup/scheduled'),
+    restores: menuOption(bm, 'Restores', '/graph/backup/restore'),
+    storageLocations: menuOption(bm, 'Storage Locations', '/graph/backup/locations'),
   }),
   configuration: new LeftMenu('Configuration', '/graph/inventory/services',
     {

--- a/tests/pages/leftNavMenu.js
+++ b/tests/pages/leftNavMenu.js
@@ -102,10 +102,7 @@ module.exports = {
       configurationAdvisors: menuOption(ad, 'Configuration Advisors', '/graph/advisors/configuration'),
       securityAdvisors: menuOption(ad, 'Security Advisors', '/graph/advisors/security'),
     }),
-  backups: new LeftMenu('Backup', '/graph/backup', {
-    backupsInventory: menuOption(bm, 'All DBaaSBackups', '/graph/backup/inventory'),
-
-  }),
+  backups: new LeftMenu('Backup', '/graph/backup'),
   configuration: new LeftMenu('Configuration', '/graph/inventory/services',
     {
       serviceAccounts: menuOption(co, 'Service accounts', '/graph/org/serviceaccounts'),

--- a/tests/pages/leftNavMenu.js
+++ b/tests/pages/leftNavMenu.js
@@ -12,6 +12,7 @@ const sa = 'Server admin';
 const co = 'Configuration';
 const al = 'Alerting';
 const ad = 'Advisors';
+const bm = 'Backups';
 
 /**
  * Implements left Navigation Grafana Menu. Intended to be used UX goes, ex.:
@@ -101,6 +102,10 @@ module.exports = {
       configurationAdvisors: menuOption(ad, 'Configuration Advisors', '/graph/advisors/configuration'),
       securityAdvisors: menuOption(ad, 'Security Advisors', '/graph/advisors/security'),
     }),
+  backups: new LeftMenu('Backup', '/graph/backup', {
+    backupsInventory: menuOption(bm, 'All DBaaSBackups', '/graph/backup/inventory'),
+
+  }),
   configuration: new LeftMenu('Configuration', '/graph/inventory/services',
     {
       serviceAccounts: menuOption(co, 'Service accounts', '/graph/org/serviceaccounts'),


### PR DESCRIPTION
* Verify at the beginning of the test case that BM is enabled by default 
* Verify that the BM toggle is on the Advance settings page by default.
* Verify that the BM icon is visible on the homepage.