### PR TITLE
PMM-7 fix PMM-T1512 aws key tooltip

### DIFF
--- a/tests/DbaaS/verifyDBaaS_test.js
+++ b/tests/DbaaS/verifyDBaaS_test.js
@@ -385,8 +385,8 @@ Scenario('@PMM-T1512 Verify tooltips work properly for DBaaS page @dbaas',
     I.click(dbaasPage.tabs.kubernetesClusterTab.eksClusterLabel);
     const tooltips = [
       dbaasPage.tooltips.clusterType,
-      dbaasPage.tooltips.awsAccessKeyId,
       dbaasPage.tooltips.awsSecretAccessKey,
+      dbaasPage.tooltips.awsAccessKeyId,
     ];
 
     for (const tooltip of tooltips) {


### PR DESCRIPTION
Changing the order of tooltips because the lower tooltip icon is hides under the upper tooltip on mouse hover

https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/2594/pipeline/