### PR TITLE
PMM-7-fix-PMM-T486-settings-public-address

### DIFF
--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -372,39 +372,6 @@ Scenario(
 ).retry(2);
 
 Scenario(
-  'PMM-T1328 Verify public address is set automatically on Percona Platform page once connected to Portal @nightly',
-  async ({
-    I, pmmSettingsPage, portalAPI, perconaPlatformPage, settingsAPI,
-  }) => {
-    await settingsAPI.changeSettings({ publicAddress: '' });
-
-    const serverAddressIP = process.env.VM_IP;
-
-    const newAdminUser = await portalAPI.getUser();
-
-    await portalAPI.oktaCreateUser(newAdminUser);
-    const platformToken = await portalAPI.getUserAccessToken(newAdminUser.email, newAdminUser.password);
-
-    await portalAPI.apiCreateOrg(platformToken);
-    await perconaPlatformPage.openPerconaPlatform();
-    await perconaPlatformPage.connectToPortal(platformToken, `Test Server ${Date.now()}`, true);
-    await pmmSettingsPage.openAdvancedSettings();
-
-    await pmmSettingsPage.verifyTooltip(pmmSettingsPage.tooltips.advancedSettings.publicAddress);
-
-    await I.waitForVisible(pmmSettingsPage.fields.publicAddressInput, 30);
-    I.seeElement(pmmSettingsPage.fields.publicAddressButton);
-    const publicAddressValue = await I.grabValueFrom(pmmSettingsPage.fields.publicAddressInput);
-
-    I.assertTrue(publicAddressValue.length > 0, 'Expected the Public Address Input Field to be not empty!');
-    await pmmSettingsPage.waitForPmmSettingsPageLoaded();
-
-    await I.assertEqual(serverAddressIP, publicAddressValue,
-      `Expected the Public Address to be saved and Match ${publicAddressValue}`);
-  },
-).retry(2);
-
-Scenario(
   'PMM-T486 - Verify Public Address in PMM Settings @settings @nightly',
   async ({ I, pmmSettingsPage, settingsAPI }) => {
     await settingsAPI.changeSettings({ publicAddress: '' });
@@ -467,3 +434,35 @@ Scenario('PMM-T1401 Verify Percona Alerting wording in Settings @max-length @set
   pmmSettingsPage.verifySwitch(pmmSettingsPage.fields.perconaAlertingSwitchInput, 'on');
   await pmmSettingsPage.verifyTooltip(pmmSettingsPage.tooltips.advancedSettings.perconaAlerting);
 });
+
+Scenario(
+  'PMM-T1328 Verify public address is set automatically on Percona Platform page once connected to Portal @nightly',
+  async ({
+    I, pmmSettingsPage, portalAPI, perconaPlatformPage, settingsAPI,
+  }) => {
+    await settingsAPI.changeSettings({ publicAddress: '' });
+
+    const serverAddressIP = process.env.VM_IP;
+    const newAdminUser = await portalAPI.getUser();
+
+    await portalAPI.oktaCreateUser(newAdminUser);
+    const platformToken = await portalAPI.getUserAccessToken(newAdminUser.email, newAdminUser.password);
+
+    await portalAPI.apiCreateOrg(platformToken);
+    await perconaPlatformPage.openPerconaPlatform();
+    await perconaPlatformPage.connectToPortal(platformToken, `Test Server ${Date.now()}`, true);
+    await pmmSettingsPage.openAdvancedSettings();
+
+    await pmmSettingsPage.verifyTooltip(pmmSettingsPage.tooltips.advancedSettings.publicAddress);
+
+    await I.waitForVisible(pmmSettingsPage.fields.publicAddressInput, 30);
+    I.seeElement(pmmSettingsPage.fields.publicAddressButton);
+    const publicAddressValue = await I.grabValueFrom(pmmSettingsPage.fields.publicAddressInput);
+
+    I.assertTrue(publicAddressValue.length > 0, 'Expected the Public Address Input Field to be not empty!');
+    await pmmSettingsPage.waitForPmmSettingsPageLoaded();
+
+    await I.assertEqual(serverAddressIP, publicAddressValue,
+      `Expected the Public Address to be saved and Match ${publicAddressValue}`);
+  },
+).retry(2);

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -392,7 +392,7 @@ Scenario(
     I.assertEqual(publicAddressAfterRefresh, publicAddressValue,
       `Expected the Public Address to be saved and Match ${publicAddressValue}`);
   },
-).retry(2);
+).retry(1);
 
 Scenario(
   'PMM-T254 ensure Advisors are on by default @instances',
@@ -465,4 +465,4 @@ Scenario(
     await I.assertEqual(serverAddressIP, publicAddressValue,
       `Expected the Public Address to be saved and Match ${publicAddressValue}`);
   },
-).retry(2);
+).retry(1);


### PR DESCRIPTION
The cause of PMM-T486 - Verify Public Address in PMM Settings 502 Bad Gateway failures seems to be a test that run before (PMM-T1328 Verify public address is set automatically on Percona Platform page once connected to Portal) - Grafana restarts every time when a public address is changed after PMM is connected with Portal so moving the Portal test to the bottom as a workaround.

Looks stable now, 3 success runs in row:
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-ui-test-nightly/detail/pmm2-ui-test-nightly/1812/tests/
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-ui-test-nightly/detail/pmm2-ui-test-nightly/1811/tests/
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-ui-test-nightly/detail/pmm2-ui-test-nightly/1810/tests