### PR TITLE
PMM-7 added reused get version job

### DIFF
--- a/.github/workflows/pmm-upgrade-ui-tests-matrix-full.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests-matrix-full.yml
@@ -24,48 +24,12 @@ on:
           - dev-latest
 
 jobs:
-  push_versions:
-    name: Push repo versions
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    outputs:
-      start_version: ${{ steps.get-start.outputs.result }}
-      finish_version: ${{ steps.get-finish.outputs.result }}
-      version_matrix: ${{ steps.get-matrix.outputs.result }}
-    steps:
-      - name: Discover latest versions
-        shell: bash
-        run: |
-          r_latest=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name  | grep -v latest | sort -V | tail -n1)
-          rc_latest=$(wget -q "https://registry.hub.docker.com/v2/repositories/perconalab/pmm-client/tags?page_size=25&name=rc" -O - | jq -r .results[].name  | grep 2.*.*-rc$ | sort -V | tail -n1)
-          rc_minor=$(echo $rc_latest | awk -F. '{print $2}')
-          d_latest="2.$((++rc_minor)).0"
-          
-          echo "release_latest=$r_latest" >> $GITHUB_ENV
-          echo "rc_latest=$rc_latest" >> $GITHUB_ENV
-          echo "dev_latest=$d_latest" >> $GITHUB_ENV
-
-      - name: Get finish version string
-        id: get-finish
-        shell: bash
-        run: |
-          if [[ "${{ inputs.repository }}" = "dev-latest" ]]; then
-            echo "result=$dev_latest" >> "$GITHUB_OUTPUT"
-          fi          
-          if [[ "${{ inputs.repository }}" = "release candidate" ]]; then
-            echo "result=$rc_latest" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ inputs.repository }}" = "release" ]]; then
-            echo "result=$release_latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Get versions matrix
-        id: get-matrix
-        shell: bash
-        run: |
-          array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -10)
-          jq -c -n '$ARGS.positional' --args ${array[@]}
-          echo "result=$(jq -c -n '$ARGS.positional' --args '2.11.0' ${array[@]})" >> "$GITHUB_OUTPUT"
+  get_versions:
+    name: Get versions
+    uses: ./.github/workflows/pmm-version-getter.yml
+    with:
+      repository: ${{ inputs.repository || 'dev-latest'}}
+      matrix_range: 10
 
   configuration:
     name: 'Configuration / Settings'
@@ -75,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        old_version: ${{ fromJSON(needs.push_versions.outputs.version_matrix) }}
+        old_version: ${{ fromJSON(needs.get_versions.outputs.version_matrix) }}
         upgrade_type: ["UI way", "Docker way"]
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch || 'main' }}
@@ -87,8 +51,8 @@ jobs:
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
       services_list: ''
       repository: ${{ inputs.repository || 'dev-latest'}}
-      version_string_from: ${{needs.push_versions.outputs.start_version}}
-      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+      version_string_from: ${{needs.get_versions.outputs.start_version}}
+      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 
   rbac:
     name: "RBAC / User Roles"
@@ -98,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        old_version: ${{ fromJSON(needs.push_versions.outputs.version_matrix) }}
+        old_version: ${{ fromJSON(needs.get_versions.outputs.version_matrix) }}
         upgrade_type: ["UI way", "Docker way"]
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch || 'main' }}
@@ -110,8 +74,8 @@ jobs:
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
       services_list: '--addclient=ps,1 --addclient=pdpgsql,1'
       repository: ${{ inputs.repository || 'dev-latest'}}
-      version_string_from: ${{needs.push_versions.outputs.start_version}}
-      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+      version_string_from: ${{needs.get_versions.outputs.start_version}}
+      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 
 # TODO: add / in the job names for good sub-jobs grouping
 #  portal:
@@ -129,8 +93,8 @@ jobs:
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: ''
 #      repository: ${{ inputs.repository }}
-#      version_string_from: ${{needs.push_versions.outputs.start_version}}
-#      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+#      version_string_from: ${{needs.get_versions.outputs.start_version}}
+#      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 #
 #  inventory:
 #    name: 'Inventory'
@@ -147,5 +111,5 @@ jobs:
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: '--addclient=modb,1'
 #      repository: ${{ inputs.repository }}
-#      version_string_from: ${{needs.push_versions.outputs.start_version}}
-#      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+#      version_string_from: ${{needs.get_versions.outputs.start_version}}
+#      version_string_to: ${{needs.get_versions.outputs.finish_version}}

--- a/.github/workflows/pmm-upgrade-ui-tests-matrix-full.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests-matrix-full.yml
@@ -35,7 +35,7 @@ jobs:
     name: 'Configuration / Settings'
     uses: ./.github/workflows/upgrade-tests-pipeline.yml
     secrets: inherit
-    needs: push_versions
+    needs: get_versions
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +58,7 @@ jobs:
     name: "RBAC / User Roles"
     uses: ./.github/workflows/upgrade-tests-pipeline.yml
     secrets: inherit
-    needs: push_versions
+    needs: get_versions
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +82,7 @@ jobs:
 #    name: Portal
 #    uses: ./.github/workflows/upgrade-tests-pipeline.yml
 #    secrets: inherit
-#    needs: push_versions
+#    needs: get_versions
 #    with:
 #      pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
 #      pre_upgrade_tests: '@pre-pmm-portal-upgrade'
@@ -100,7 +100,7 @@ jobs:
 #    name: 'Inventory'
 #    uses: ./.github/workflows/upgrade-tests-pipeline.yml
 #    secrets: inherit
-#    needs: push_versions
+#    needs: get_versions
 #    with:
 #      pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
 #      pre_upgrade_tests: '@inventory-pre-upgrade'

--- a/.github/workflows/pmm-upgrade-ui-tests-matrix.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests-matrix.yml
@@ -48,14 +48,13 @@ jobs:
       fail-fast: false
       matrix:
         old_version: ${{ fromJSON(needs.get_versions.outputs.version_matrix) }}
-        upgrade_type: ["UI way", "Docker way"]
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch || 'main' }}
       pre_upgrade_tests: '@config-pre-upgrade'
       post_upgrade_tests: '@config-post-upgrade'
       pmm_server_start_version: ${{ matrix.old_version }}
       pmm_client_start_version: ${{ matrix.old_version }}
-      upgrade_type: ${{ matrix.upgrade_type }}
+      upgrade_type: ${{ inputs.upgrade_type || 'Docker way' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
       services_list: ''
       repository: ${{ inputs.repository || 'dev-latest'}}
@@ -71,14 +70,13 @@ jobs:
       fail-fast: false
       matrix:
         old_version: ${{ fromJSON(needs.get_versions.outputs.version_matrix) }}
-        upgrade_type: ["UI way", "Docker way"]
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch || 'main' }}
       pre_upgrade_tests: '@rbac-pre-upgrade'
       post_upgrade_tests: '@rbac-post-upgrade'
       pmm_server_start_version: ${{ matrix.old_version }}
       pmm_client_start_version: ${{ matrix.old_version }}
-      upgrade_type: ${{ matrix.upgrade_type }}
+      upgrade_type: ${{ inputs.upgrade_type || 'Docker way' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
       services_list: '--addclient=ps,1 --addclient=pdpgsql,1'
       repository: ${{ inputs.repository }}
@@ -97,7 +95,7 @@ jobs:
 #      post_upgrade_tests: '@post-pmm-portal-upgrade'
 #      pmm_server_start_version: ${{ inputs.pmm_server_start_version }}
 #      pmm_client_start_version: ${{ inputs.pmm_client_start_version }}
-#      upgrade_type: ${{ inputs.upgrade_type }}
+#      upgrade_type: ${{ inputs.upgrade_type || 'Docker way' }}
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: ''
 #      repository: ${{ inputs.repository }}
@@ -115,7 +113,7 @@ jobs:
 #      post_upgrade_tests: '@inventory-post-upgrade'
 #      pmm_server_start_version: ${{ inputs.pmm_server_start_version }}
 #      pmm_client_start_version: ${{ inputs.pmm_client_start_version }}
-#      upgrade_type: ${{ inputs.upgrade_type }}
+#      upgrade_type: ${{ inputs.upgrade_type || 'Docker way' }}
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: '--addclient=modb,1'
 #      repository: ${{ inputs.repository }}

--- a/.github/workflows/pmm-upgrade-ui-tests-matrix.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests-matrix.yml
@@ -43,7 +43,7 @@ jobs:
     name: 'Configuration / Settings'
     uses: ./.github/workflows/upgrade-tests-pipeline.yml
     secrets: inherit
-    needs: push_versions
+    needs: get_versions
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +66,7 @@ jobs:
     name: "RBAC / User Roles"
     uses: ./.github/workflows/upgrade-tests-pipeline.yml
     secrets: inherit
-    needs: push_versions
+    needs: get_versions
     strategy:
       fail-fast: false
       matrix:
@@ -90,7 +90,7 @@ jobs:
 #    name: Portal
 #    uses: ./.github/workflows/upgrade-tests-pipeline.yml
 #    secrets: inherit
-#    needs: push_versions
+#    needs: get_versions
 #    with:
 #      pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
 #      pre_upgrade_tests: '@pre-pmm-portal-upgrade'
@@ -108,7 +108,7 @@ jobs:
 #    name: 'Inventory'
 #    uses: ./.github/workflows/upgrade-tests-pipeline.yml
 #    secrets: inherit
-#    needs: push_versions
+#    needs: get_versions
 #    with:
 #      pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
 #      pre_upgrade_tests: '@inventory-pre-upgrade'

--- a/.github/workflows/pmm-upgrade-ui-tests-matrix.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests-matrix.yml
@@ -32,50 +32,12 @@ on:
           - dev-latest
 
 jobs:
-  push_versions:
-    name: Push repo versions
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    outputs:
-      start_version: ${{ steps.get-start.outputs.result }}
-      finish_version: ${{ steps.get-finish.outputs.result }}
-      version_matrix: ${{ steps.get-matrix.outputs.result }}
-    steps:
-      - name: Discover latest versions
-        shell: bash
-        run: |
-          r_latest=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name  | grep -v latest | sort -V | tail -n1)
-          rc_latest=$(wget -q "https://registry.hub.docker.com/v2/repositories/perconalab/pmm-client/tags?page_size=25&name=rc" -O - | jq -r .results[].name  | grep 2.*.*-rc$ | sort -V | tail -n1)
-          rc_minor=$(echo $rc_latest | awk -F. '{print $2}')
-          d_latest="2.$((++rc_minor)).0"
-          
-          echo "release_latest=$r_latest" >> $GITHUB_ENV
-          echo "rc_latest=$rc_latest" >> $GITHUB_ENV
-          echo "dev_latest=$d_latest" >> $GITHUB_ENV
-
-      - name: Get finish version string
-        id: get-finish
-        shell: bash
-        run: |
-          if [[ "${{ inputs.repository }}" = "dev-latest" ]]; then
-            echo "result=$dev_latest" >> "$GITHUB_OUTPUT"
-          fi          
-          if [[ "${{ inputs.repository }}" = "release candidate" ]]; then
-            echo "result=$rc_latest" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ inputs.repository }}" = "release" ]]; then
-            echo "result=$release_latest" >> "$GITHUB_OUTPUT"
-          fi
-          ### Debug only! remove with push!
-          echo "result=$release_latest" >> "$GITHUB_OUTPUT"
-
-      - name: Get versions matrix
-        id: get-matrix
-        shell: bash
-        run: |
-          array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -10)
-          jq -c -n '$ARGS.positional' --args ${array[@]}
-          echo "result=$(jq -c -n '$ARGS.positional' --args '2.11.0' ${array[@]})" >> "$GITHUB_OUTPUT"
+  get_versions:
+    name: Get versions
+    uses: ./.github/workflows/pmm-version-getter.yml
+    with:
+      repository: ${{ inputs.repository || 'dev-latest'}}
+      matrix_range: 10
 
   configuration:
     name: 'Configuration / Settings'
@@ -85,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        old_version: ${{ fromJSON(needs.push_versions.outputs.version_matrix) }}
+        old_version: ${{ fromJSON(needs.get_versions.outputs.version_matrix) }}
         upgrade_type: ["UI way", "Docker way"]
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch || 'main' }}
@@ -97,8 +59,8 @@ jobs:
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
       services_list: ''
       repository: ${{ inputs.repository || 'dev-latest'}}
-      version_string_from: ${{needs.push_versions.outputs.start_version}}
-      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+      version_string_from: ${{needs.get_versions.outputs.start_version}}
+      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 
   rbac:
     name: "RBAC / User Roles"
@@ -108,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        old_version: ${{ fromJSON(needs.push_versions.outputs.version_matrix) }}
+        old_version: ${{ fromJSON(needs.get_versions.outputs.version_matrix) }}
         upgrade_type: ["UI way", "Docker way"]
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch || 'main' }}
@@ -120,8 +82,8 @@ jobs:
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
       services_list: '--addclient=ps,1 --addclient=pdpgsql,1'
       repository: ${{ inputs.repository }}
-      version_string_from: ${{needs.push_versions.outputs.start_version}}
-      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+      version_string_from: ${{needs.get_versions.outputs.start_version}}
+      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 
 # TODO: add / in the job names for good sub-jobs grouping
 #  portal:
@@ -139,8 +101,8 @@ jobs:
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: ''
 #      repository: ${{ inputs.repository }}
-#      version_string_from: ${{needs.push_versions.outputs.start_version}}
-#      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+#      version_string_from: ${{needs.get_versions.outputs.start_version}}
+#      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 #
 #  inventory:
 #    name: 'Inventory'
@@ -157,5 +119,5 @@ jobs:
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: '--addclient=modb,1'
 #      repository: ${{ inputs.repository }}
-#      version_string_from: ${{needs.push_versions.outputs.start_version}}
-#      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+#      version_string_from: ${{needs.get_versions.outputs.start_version}}
+#      version_string_to: ${{needs.get_versions.outputs.finish_version}}

--- a/.github/workflows/pmm-upgrade-ui-tests.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests.yml
@@ -76,6 +76,7 @@ jobs:
     name: Get versions
     uses: ./.github/workflows/pmm-version-getter.yml
     with:
+      pmm_server_start_version: ${{ inputs.pmm_server_start_version || 'latest'}}
       repository: ${{ inputs.repository || 'dev-latest'}}
       matrix_range: 10
 

--- a/.github/workflows/pmm-upgrade-ui-tests.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests.yml
@@ -117,7 +117,7 @@ jobs:
       version_string_to: ${{needs.get_versions.outputs.finish_version}}
 
 #  portal:
-#    name: Portal
+#    name: Portal / Portal
 #    uses: ./.github/workflows/upgrade-tests-pipeline.yml
 #    secrets: inherit
 #    needs: get_versions

--- a/.github/workflows/pmm-upgrade-ui-tests.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests.yml
@@ -1,8 +1,6 @@
 name: PMM Upgrade UI Tests
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       pmm_ui_tests_branch:
@@ -74,62 +72,12 @@ on:
         type: string
 
 jobs:
-  push_versions:
-    name: Push repo versions
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    outputs:
-      start_version: ${{ steps.get-start.outputs.result }}
-      finish_version: ${{ steps.get-finish.outputs.result }}
-    steps:
-      - name: Prevent upgrade to the same version
-        shell: bash
-        run: |
-          if [[ "${{ inputs.pmm_server_start_version }}" = "latest" && "${{ inputs.repository }}" = "release" ]]; then
-            echo "Upgrade to the same version is forbidden!"
-            exit 1
-          fi
-          if [[ "${{ inputs.pmm_server_start_version }}" = "dev-latest" && "${{ inputs.repository }}" = "dev-latest" ]]; then
-            echo "Upgrade to the same version is forbidden!"
-            exit 1
-          fi
-
-      - name: Discover latest versions
-        shell: bash
-        run: |
-          r_latest=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name  | grep -v latest | sort -V | tail -n1)
-          rc_latest=$(wget -q "https://registry.hub.docker.com/v2/repositories/perconalab/pmm-client/tags?page_size=25&name=rc" -O - | jq -r .results[].name  | grep 2.*.*-rc$ | sort -V | tail -n1)
-          rc_minor=$(echo $rc_latest | awk -F. '{print $2}')
-          d_latest="2.$((++rc_minor)).0"
-          
-          echo "release_latest=$r_latest" >> $GITHUB_ENV
-          echo "rc_latest=$rc_latest" >> $GITHUB_ENV
-          echo "dev_latest=$d_latest" >> $GITHUB_ENV
-
-      - name: Get start version string
-        id: get-start
-        shell: bash
-        run: |
-          if [[ "${{ inputs.pmm_server_start_version }}" = "latest" ]]; then
-            echo "result=$release_latest" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ inputs.pmm_server_start_version }}" = "dev-latest" ]]; then
-            echo "result=$dev_latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Get finish version string
-        id: get-finish
-        shell: bash
-        run: |
-          if [[ "${{ inputs.repository }}" = "dev-latest" ]]; then
-            echo "result=$dev_latest" >> "$GITHUB_OUTPUT"
-          fi          
-          if [[ "${{ inputs.repository }}" = "release candidate" ]]; then
-            echo "result=$rc_latest" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ inputs.repository }}" = "release" ]]; then
-            echo "result=$release_latest" >> "$GITHUB_OUTPUT"
-          fi
+  get_versions:
+    name: Get versions
+    uses: ./.github/workflows/pmm-version-getter.yml
+    with:
+      repository: ${{ inputs.repository || 'dev-latest'}}
+      matrix_range: 10
 
   configuration:
     name: 'Configuration / Settings'
@@ -146,8 +94,8 @@ jobs:
       pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
       services_list: ''
       repository: ${{ inputs.repository }}
-      version_string_from: ${{needs.push_versions.outputs.start_version}}
-      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+      version_string_from: ${{needs.get_versions.outputs.start_version}}
+      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 
   rbac:
     name: RBAC
@@ -164,8 +112,8 @@ jobs:
       pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
       services_list: '--addclient=ps,1 --addclient=pdpgsql,1'
       repository: ${{ inputs.repository }}
-      version_string_from: ${{needs.push_versions.outputs.start_version}}
-      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+      version_string_from: ${{needs.get_versions.outputs.start_version}}
+      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 
 #  portal:
 #    name: Portal
@@ -182,8 +130,8 @@ jobs:
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: ''
 #      repository: ${{ inputs.repository }}
-#      version_string_from: ${{needs.push_versions.outputs.start_version}}
-#      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+#      version_string_from: ${{needs.get_versions.outputs.start_version}}
+#      version_string_to: ${{needs.get_versions.outputs.finish_version}}
 #
 #  inventory:
 #    name: 'Inventory'
@@ -200,5 +148,5 @@ jobs:
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
 #      services_list: '--addclient=modb,1'
 #      repository: ${{ inputs.repository }}
-#      version_string_from: ${{needs.push_versions.outputs.start_version}}
-#      version_string_to: ${{needs.push_versions.outputs.finish_version}}
+#      version_string_from: ${{needs.get_versions.outputs.start_version}}
+#      version_string_to: ${{needs.get_versions.outputs.finish_version}}

--- a/.github/workflows/pmm-upgrade-ui-tests.yml
+++ b/.github/workflows/pmm-upgrade-ui-tests.yml
@@ -83,7 +83,7 @@ jobs:
     name: 'Configuration / Settings'
     uses: ./.github/workflows/upgrade-tests-pipeline.yml
     secrets: inherit
-    needs: push_versions
+    needs: get_versions
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
       pre_upgrade_tests: '@config-pre-upgrade'
@@ -101,7 +101,7 @@ jobs:
     name: RBAC
     uses: ./.github/workflows/upgrade-tests-pipeline.yml
     secrets: inherit
-    needs: push_versions
+    needs: get_versions
     with:
       pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
       pre_upgrade_tests: '@rbac-pre-upgrade'
@@ -119,7 +119,7 @@ jobs:
 #    name: Portal
 #    uses: ./.github/workflows/upgrade-tests-pipeline.yml
 #    secrets: inherit
-#    needs: push_versions
+#    needs: get_versions
 #    with:
 #      pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
 #      pre_upgrade_tests: '@pre-pmm-portal-upgrade'
@@ -137,7 +137,7 @@ jobs:
 #    name: 'Inventory'
 #    uses: ./.github/workflows/upgrade-tests-pipeline.yml
 #    secrets: inherit
-#    needs: push_versions
+#    needs: get_versions
 #    with:
 #      pmm_ui_tests_branch: ${{ inputs.pmm_ui_tests_branch }}
 #      pre_upgrade_tests: '@inventory-pre-upgrade'

--- a/.github/workflows/pmm-version-getter.yml
+++ b/.github/workflows/pmm-version-getter.yml
@@ -1,0 +1,98 @@
+name: "PMM Version detector"
+
+on:
+  workflow_call:
+    inputs:
+      pmm_server_start_version:
+        description: 'PMM Server version to upgrade (latest|dev-latest|x.xx.x|x.xx.x-rc)'
+        default: 'latest'
+        type: string
+      pmm_client_start_version:
+        description: 'PMM Client version to upgrade from (dev-latest|pmm2-latest|pmm2-rc|x.xx.x)'
+        default: 'pmm2-latest'
+        type: string
+      repository:
+        description: 'Upgrade to:'
+        required: true
+        default: 'dev-latest'
+        type: string
+      matrix_range:
+        default: 10
+        type: number
+    outputs:
+      start_version:
+        description: "Version detected based on tag input"
+        value: ${{ jobs.push_versions.outputs.start_version }}
+      finish_version:
+        description: "Version detected based on repository input"
+        value: ${{ jobs.push_versions.outputs.finish_version }}
+      version_matrix:
+        description: "Json array with number of last versions"
+        value: ${{ jobs.push_versions.outputs.version_matrix }}
+
+jobs:
+  push_versions:
+    name: Push repo versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      start_version: ${{ steps.get-start.outputs.result }}
+      finish_version: ${{ steps.get-finish.outputs.result }}
+      version_matrix: ${{ steps.get-matrix.outputs.result }}
+    steps:
+      - name: Prevent upgrade to the same version
+        shell: bash
+        run: |
+          if [[ "${{ inputs.pmm_server_start_version }}" = "latest" && "${{ inputs.repository }}" = "release" ]]; then
+            echo "Upgrade to the same version is forbidden!"
+            exit 1
+          fi
+          if [[ "${{ inputs.pmm_server_start_version }}" = "dev-latest" && "${{ inputs.repository }}" = "dev-latest" ]]; then
+            echo "Upgrade to the same version is forbidden!"
+            exit 1
+          fi
+
+      - name: Discover latest versions
+        shell: bash
+        run: |
+          r_latest=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name  | grep -v latest | sort -V | tail -n1)
+          rc_latest=$(wget -q "https://registry.hub.docker.com/v2/repositories/perconalab/pmm-client/tags?page_size=25&name=rc" -O - | jq -r .results[].name  | grep 2.*.*-rc$ | sort -V | tail -n1)
+          rc_minor=$(echo $rc_latest | awk -F. '{print $2}')
+          d_latest="2.$((++rc_minor)).0"
+          
+          echo "release_latest=$r_latest" >> $GITHUB_ENV
+          echo "rc_latest=$rc_latest" >> $GITHUB_ENV
+          echo "dev_latest=$d_latest" >> $GITHUB_ENV
+
+      - name: Get start version string
+        id: get-start
+        shell: bash
+        run: |
+          if [[ "${{ inputs.pmm_server_start_version }}" = "latest" ]]; then
+            echo "result=$release_latest" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "${{ inputs.pmm_server_start_version }}" = "dev-latest" ]]; then
+            echo "result=$dev_latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get finish version string
+        id: get-finish
+        shell: bash
+        run: |
+          if [[  "${{ inputs.repository }}" == "dev-latest" ]]; then
+            echo "result=$dev_latest" >> "$GITHUB_OUTPUT"
+          fi          
+          if [[ "${{ inputs.repository }}" == "release candidate" ]]; then
+            echo "result=$rc_latest" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "${{ inputs.repository }}" == "release" ]]; then
+            echo "result=$release_latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get versions matrix
+        id: get-matrix
+        shell: bash
+        run: |
+          array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -10)
+          jq -c -n '$ARGS.positional' --args ${array[@]}
+          echo "result=$(jq -c -n '$ARGS.positional' --args '2.11.0' ${array[@]})" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pmm-version-getter.yml
+++ b/.github/workflows/pmm-version-getter.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   push_versions:
-    name: Push repo versions
+    name: Get versions
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
@@ -41,11 +41,11 @@ jobs:
       - name: Prevent upgrade to the same version
         shell: bash
         run: |
-          if [[ "${{ inputs.pmm_server_start_version }}" = "latest" && "${{ inputs.repository }}" = "release" ]]; then
+          if [[ "${{ inputs.pmm_server_start_version }}" == "latest" && "${{ inputs.repository }}" == "release" ]]; then
             echo "Upgrade to the same version is forbidden!"
             exit 1
           fi
-          if [[ "${{ inputs.pmm_server_start_version }}" = "dev-latest" && "${{ inputs.repository }}" = "dev-latest" ]]; then
+          if [[ "${{ inputs.pmm_server_start_version }}" == "dev-latest" && "${{ inputs.repository }}" == "dev-latest" ]]; then
             echo "Upgrade to the same version is forbidden!"
             exit 1
           fi
@@ -66,10 +66,10 @@ jobs:
         id: get-start
         shell: bash
         run: |
-          if [[ "${{ inputs.pmm_server_start_version }}" = "latest" ]]; then
+          if [[ "${{ inputs.pmm_server_start_version }}" == "latest" ]]; then
             echo "result=$release_latest" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{ inputs.pmm_server_start_version }}" = "dev-latest" ]]; then
+          if [[ "${{ inputs.pmm_server_start_version }}" == "dev-latest" ]]; then
             echo "result=$dev_latest" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/pmm-version-getter.yml
+++ b/.github/workflows/pmm-version-getter.yml
@@ -93,9 +93,9 @@ jobs:
         run: |
           range=${{ inputs.matrix_range }}
           if [[ "${{ inputs.repository }}" == "release" ]]; then
-            array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -$((++range)) | head -$((range))
+            array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -$((++range)) | head -$((range)))
           else
-            array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -$((range))
+            array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -$((range)))
           fi
           jq -c -n '$ARGS.positional' --args ${array[@]}
           echo "result=$(jq -c -n '$ARGS.positional' --args '2.11.0' ${array[@]})" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pmm-version-getter.yml
+++ b/.github/workflows/pmm-version-getter.yml
@@ -5,11 +5,9 @@ on:
     inputs:
       pmm_server_start_version:
         description: 'PMM Server version to upgrade (latest|dev-latest|x.xx.x|x.xx.x-rc)'
-        default: 'latest'
         type: string
       pmm_client_start_version:
         description: 'PMM Client version to upgrade from (dev-latest|pmm2-latest|pmm2-rc|x.xx.x)'
-        default: 'pmm2-latest'
         type: string
       repository:
         description: 'Upgrade to:'

--- a/.github/workflows/pmm-version-getter.yml
+++ b/.github/workflows/pmm-version-getter.yml
@@ -91,6 +91,11 @@ jobs:
         id: get-matrix
         shell: bash
         run: |
-          array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -10)
+          range=${{ inputs.matrix_range }}
+          if [[ "${{ inputs.repository }}" == "release" ]]; then
+            array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -$((++range)) | head -$((range))
+          else
+            array=$(wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=50 -O - | jq -r .results[].name | grep -v latest | sort -V | grep -E '[[:digit:]]\.[[:digit:]]+\.[[:digit:]]' | tail -$((range))
+          fi
           jq -c -n '$ARGS.positional' --args ${array[@]}
           echo "result=$(jq -c -n '$ARGS.positional' --args '2.11.0' ${array[@]})" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Required to fix upgrade to version string for scheduled jobs:
* Added reusable workflow to detect latest versions sting to avoid code duplication.
* Fixed matrix generator for "upgrade to release version" choice 