### PR TITLE
updates, fix test to verify only pdpgsql 16 for now

### DIFF
--- a/tests/verifyTLSPostgresRemoteInstance_test.js
+++ b/tests/verifyTLSPostgresRemoteInstance_test.js
@@ -11,7 +11,7 @@ Before(async ({ I, settingsAPI }) => {
 
 const instances = new DataTable(['serviceName', 'version', 'container', 'serviceType', 'metric', 'maxQueryLength']);
 
-instances.add(['pgsql_17_ssl_service', '17', 'pdpgsql_pgsm_ssl_17', 'postgres_ssl', 'pg_up', '7']);
+instances.add(['pgsql_16_ssl_service', '16', 'pdpgsql_pgsm_ssl_16', 'postgres_ssl', 'pg_up', '7']);
 // instances.add(['pgsql_14_ssl_service', '14', 'pdpgsql_pgsm_ssl_14', 'postgres_ssl', 'pg_stat_database_xact_rollback', '7']);
 // instances.add(['pgsql_14_ssl_service', '13', 'pdpgsql_pgsm_ssl_13', 'postgres_ssl', 'pg_stat_database_xact_rollback', '7']);
 // instances.add(['pgsql_12_ssl_service', '12', 'pdpgsql_pgsm_ssl_12', 'postgres_ssl', 'pg_stat_database_xact_rollback', '7']);


### PR DESCRIPTION
updates, fix test to verify only pdpgsql 16 for now
test runs https://pmm.cd.percona.com/blue/organizations/jenkins/pmm3-ui-tests/detail/pmm3-ui-tests/824/pipeline