### PR TITLE
PMM-7 Fix product tour tests

### DIFF
--- a/tests/helper/grafana_helper.js
+++ b/tests/helper/grafana_helper.js
@@ -34,7 +34,7 @@ class Grafana extends Helper {
     Playwright.setPlaywrightRequestHeaders({ Authorization: `Basic ${basicAuthEncoded}` });
   }
 
-  async enableProductTour() {
+  async enableProductTour(snooze = false) {
     const { Playwright } = this.helpers;
 
     await Playwright.page.route('**/v1/users/me', async (route, request) => {
@@ -45,7 +45,7 @@ class Grafana extends Helper {
             user_id: 1,
             product_tour_completed: false,
             alerting_tour_completed: false,
-            snoozed_pmm_version: '',
+            snoozed_pmm_version: snooze ? '3.2.0' : '',
           }),
         });
       } else {

--- a/tests/pages/homePage.js
+++ b/tests/pages/homePage.js
@@ -12,7 +12,7 @@ module.exports = {
   genericOauthUrl: 'graph/login/generic_oauth',
   requestEnd: '/v1/Updates/Check',
   elements: {
-    pageContent: locate('//div[@id="pageContent"]'),
+    pageContent: locate('//main[@id="pageContent"]'),
   },
   fields: {
     systemsUnderMonitoringCount:

--- a/tests/product-tour/productTour_test.js
+++ b/tests/product-tour/productTour_test.js
@@ -3,10 +3,11 @@ Feature('Pmm Product tour tests');
 Before(async ({ I, settingsAPI }) => {
   await I.stopMockingProductTourApi();
   await I.Authorize();
+  // get request will create the initial state
+  await I.sendGetRequest('v1/users/me', { Authorization: `Basic ${await I.getAuth()}` });
   // todo: it would be better to disable updates once PMM-13608 is fixed
   // snooze update modal
   await settingsAPI.setTourOptions(false, true, '3.2.0');
-  await I.sendGetRequest('v1/users/me', { Authorization: `Basic ${await I.getAuth()}` });
 });
 
 Scenario('PMM-T1879 Verify that product tour dialog is displayed after check later button pressed. @grafana-pr', async ({ I, homePage }) => {

--- a/tests/product-tour/productTour_test.js
+++ b/tests/product-tour/productTour_test.js
@@ -1,8 +1,11 @@
 Feature('Pmm Product tour tests');
 
-Before(async ({ I }) => {
+Before(async ({ I, settingsAPI }) => {
   await I.stopMockingProductTourApi();
   await I.Authorize();
+  // todo: it would be better to disable updates once PMM-13608 is fixed
+  // snooze update modal
+  await settingsAPI.setTourOptions(false, true, '3.2.0');
   await I.sendGetRequest('v1/users/me', { Authorization: `Basic ${await I.getAuth()}` });
 });
 
@@ -31,7 +34,7 @@ Scenario('PMM-T1881 Verify that product tour dialog contains all the components.
 }).config('Playwright', { waitForNavigation: 'load' });
 
 Scenario('PMM-T1882 Verify that product tour dialog is not displayed after skipping @grafana-pr', async ({ I, homePage }) => {
-  await I.enableProductTour();
+  await I.enableProductTour(true);
   await I.amOnPage('');
 
   await I.waitForElement(homePage.productTour.skipButton);


### PR DESCRIPTION
Fixes product tour test failures due to the update modal appearing.

Once PMM-13608 is fixed it would be better to disable updates through settings rather than to rely on the snoozed pmm version.

Related: https://github.com/percona/grafana/pull/791