### PR TITLE
PMM-13826: 'PMM-T2009 - Verify that editor user can see failed advisors data on home dashboard @nightly

### DIFF
--- a/tests/advisors/pages/api/advisorsAPI.js
+++ b/tests/advisors/pages/api/advisorsAPI.js
@@ -8,6 +8,19 @@ module.exports = {
     mysqlEmptyPassword: 'mysql_security_1',
   },
 
+  async getAdvisorsNames() {
+    const headers = { Authorization: `Basic ${await I.getAuth()}` };
+
+    const resp = await I.sendGetRequest('v1/advisors/checks', headers);
+
+    assert.ok(
+      resp.status === 200,
+      `Failed to get Advisors. Response message is "${resp.data.message}"`,
+    );
+
+    return resp.data.checks.map((check) => check.name);
+  },
+
   async getSecurityChecksResults() {
     const headers = { Authorization: `Basic ${await I.getAuth()}` };
 

--- a/tests/configuration/permissions_test.js
+++ b/tests/configuration/permissions_test.js
@@ -264,7 +264,7 @@ Scenario(
     const advisors = await advisorsAPI.getAdvisorsNames();
 
     await advisorsAPI.startSecurityChecks(advisors);
-    await I.Authorize();
+    await I.Authorize(users.editor.username, users.editor.password);
     I.amOnPage(I.buildUrlWithParams(dashboardPage.homeDashboard.url, { refresh: '5s' }));
     I.waitForVisible(dashboardPage.homeDashboard.panelData.failedAdvisors.criticalFailedAdvisors, 480);
 

--- a/tests/configuration/permissions_test.js
+++ b/tests/configuration/permissions_test.js
@@ -266,7 +266,7 @@ Scenario(
     await advisorsAPI.startSecurityChecks(advisors);
     await I.Authorize();
     I.amOnPage(I.buildUrlWithParams(dashboardPage.homeDashboard.url, { refresh: '5s' }));
-    I.waitForVisible(dashboardPage.homeDashboard.panelData.failedAdvisors.criticalFailedAdvisors, 240);
+    I.waitForVisible(dashboardPage.homeDashboard.panelData.failedAdvisors.criticalFailedAdvisors, 480);
 
     const criticalAdvisors = await I.grabTextFrom(dashboardPage.homeDashboard.panelData.failedAdvisors.criticalFailedAdvisors);
     const errorAdvisors = await I.grabTextFrom(dashboardPage.homeDashboard.panelData.failedAdvisors.errorFailedAdvisors);

--- a/tests/configuration/permissions_test.js
+++ b/tests/configuration/permissions_test.js
@@ -259,7 +259,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T2009 - Verify that editor user can see failed advisors data on home dashboard @fb-alerting @grafana-pr',
+  'PMM-T2009 - Verify that editor user can see failed advisors data on home dashboard @nightly @grafana-pr',
   async ({ I, dashboardPage }) => {
     await I.Authorize(users.editor.username, users.editor.password);
     I.amOnPage(dashboardPage.homeDashboard.url);

--- a/tests/configuration/permissions_test.js
+++ b/tests/configuration/permissions_test.js
@@ -259,7 +259,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T2009 - Verify that editor user can see failed advisors data on home dashboard @nightly @grafana-pr',
+  'PMM-T2009 - Verify that editor user can see failed advisors data on home dashboard @nightly',
   async ({ I, dashboardPage, advisorsAPI }) => {
     const advisors = await advisorsAPI.getAdvisorsNames();
 

--- a/tests/configuration/permissions_test.js
+++ b/tests/configuration/permissions_test.js
@@ -263,7 +263,7 @@ Scenario(
   async ({ I, dashboardPage }) => {
     await I.Authorize(users.editor.username, users.editor.password);
     I.amOnPage(dashboardPage.homeDashboard.url);
-    await I.vaitForVisible(dashboardPage.homeDashboard.panels.failedAdvisorsValue());
+    await I.waitForVisible(dashboardPage.homeDashboard.panels.failedAdvisorsValue());
     const failedAdvisorsCount = await I.grabTextFrom(dashboardPage.homeDashboard.panels.failedAdvisorsValue());
 
     I.assertEqual(failedAdvisorsCount, '0', 'Failed Advisors count should be visible and should be 0');

--- a/tests/configuration/permissions_test.js
+++ b/tests/configuration/permissions_test.js
@@ -257,3 +257,15 @@ Scenario(
     I.waitForText('Insufficient access permissions.', 10, ruleTemplatesPage.elements.unathorizedMessage);
   },
 );
+
+Scenario(
+  'PMM-T9999 - Verify taht editor user can see failed @fb-alerting @grafana-pr',
+  async ({ I, dashboardPage }) => {
+    await I.Authorize(users.editor.username, users.editor.password);
+    I.amOnPage(dashboardPage.homeDashboard.url);
+    await I.vaitForVisible(dashboardPage.homeDashboard.panels.failedAdvisorsValue());
+    const failedAdvisorsCount = await I.grabTextFrom(dashboardPage.homeDashboard.panels.failedAdvisorsValue());
+
+    I.assertEqual(failedAdvisorsCount, '0', 'Failed Advisors count should be visible and should be 0');
+  },
+);

--- a/tests/configuration/permissions_test.js
+++ b/tests/configuration/permissions_test.js
@@ -259,7 +259,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T9999 - Verify taht editor user can see failed @fb-alerting @grafana-pr',
+  'PMM-T2009 - Verify that editor user can see failed advisors data on home dashboard @fb-alerting @grafana-pr',
   async ({ I, dashboardPage }) => {
     await I.Authorize(users.editor.username, users.editor.password);
     I.amOnPage(dashboardPage.homeDashboard.url);

--- a/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
+++ b/tests/configuration/verifyPMMSettingsPageFunctionality_test.js
@@ -263,8 +263,7 @@ Scenario('PMM-T1401 - Verify Percona Alerting wording in Settings @max-length @s
   await pmmSettingsPage.verifyTooltip(pmmSettingsPage.tooltips.advancedSettings.perconaAlerting);
 });
 
-// unskip after SAAS-1437 is done and 500 error is fixed
-Scenario.skip(
+Scenario(
   'PMM-T1328 Verify public address is set automatically on Percona Platform page once connected to Portal @nightly',
   async ({
     I, pmmSettingsPage, portalAPI, perconaPlatformPage, settingsAPI,

--- a/tests/dashboards/pages/homeDashboard.js
+++ b/tests/dashboards/pages/homeDashboard.js
@@ -11,8 +11,17 @@ class HomeDashboard {
         pgsql: () => `(${this.panels.monitoredServicesPanelLocator}//span)[3]`,
         proxysql: () => `(${this.panels.monitoredServicesPanelLocator}//span)[4]`,
       },
-      failedAdvisorsPanel: '//section[@data-testid="data-testid Panel header Failed advisors"]',
-      failedAdvisorsValue: () => `${this.panels.failedAdvisorsPanel}//div[@data-testid="data-testid panel content"]//span`,
+      failedAdvisors: '//section[@data-testid="data-testid Panel header Failed advisors"]',
+
+    };
+    this.panelData = {
+      failedAdvisors: {
+        insufficientPrivilege: `${this.panels.failedAdvisors}//[@data-testid="unauthorized"]`,
+        criticalFailedAdvisors: `${this.panels.failedAdvisors}//span[@data-testid="db-check-panel-critical"]`,
+        errorFailedAdvisors: `${this.panels.failedAdvisors}//span[@data-testid="db-check-panel-error"]`,
+        warningFailedAdvisors: `${this.panels.failedAdvisors}//span[@data-testid="db-check-panel-warning"]`,
+        noticeFailedAdvisors: `${this.panels.failedAdvisors}//span[@data-testid="db-check-panel-notice"]`,
+      },
     };
     this.metrics = [
       'CPU Busy',

--- a/tests/dashboards/pages/homeDashboard.js
+++ b/tests/dashboards/pages/homeDashboard.js
@@ -11,6 +11,8 @@ class HomeDashboard {
         pgsql: () => `(${this.panels.monitoredServicesPanelLocator}//span)[3]`,
         proxysql: () => `(${this.panels.monitoredServicesPanelLocator}//span)[4]`,
       },
+      failedAdvisorsPanel: '//section[@data-testid="data-testid Panel header Failed advisors"]',
+      failedAdvisorsValue: () => `${this.panels.failedAdvisorsPanel}//div[@data-testid="data-testid panel content"]//span`,
     };
     this.metrics = [
       'CPU Busy',


### PR DESCRIPTION
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm3-ui-tests-nightly/detail/pmm3-ui-tests-nightly/791/pipeline