### PR TITLE
PMM-7 Remove MySQL Query Response Time Dashboard from left menu testing

### DIFF
--- a/tests/pages/leftNavMenu.js
+++ b/tests/pages/leftNavMenu.js
@@ -71,7 +71,6 @@ module.exports = {
       mySqlInnoDbCompressionDetails: menuOption(ms, 'InnoDB compression', '/graph/d/mysql-innodb-compression/mysql-innodb-compression-details'),
 
       mySqlPerformanceSchemaDetails: menuOption(ms, 'Performance schema', '/graph/d/mysql-performance-schema/mysql-performance-schema-details'),
-      mySqlQueryResponseTimeDetails: menuOption(ms, 'Query response time', '/graph/d/mysql-queryresponsetime/mysql-query-response-time-details'),
       mysqlTableDetails: menuOption(ms, 'Table details', '/graph/d/mysql-table/mysql-table-details'),
       mySqlTokuDbDetails: menuOption(ms, 'TokuDB details', '/graph/d/mysql-tokudb/mysql-tokudb-details'),
     },


### PR DESCRIPTION
This removes the Dashboard as ticket https://perconadev.atlassian.net/browse/PMM-13782 removed it from left menu.